### PR TITLE
refactor: H2 DB를 사용하여 테스트 환경 구성

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
@@ -72,8 +72,7 @@ public class SurveyController {
     })
     @GetMapping("/{surveyId}")
     public ResponseEntity<SurveyResponseDto> getSurvey(
-        @Parameter(hidden = true) Authentication authentication,
-        @Parameter(name = "UUID 형식의 surveyId", required = true) @PathVariable UUID surveyId) {
+        @Parameter(hidden = true) Authentication authentication, @PathVariable UUID surveyId) {
         return ResponseEntity.ok(surveyService.getSurveyBySurveyIdWithRelatedQuestion(authentication, surveyId));
     }
 

--- a/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestion.java
+++ b/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestion.java
@@ -1,13 +1,6 @@
 package com.thesurvey.api.domain;
 
-import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
-import javax.persistence.Table;
+import javax.persistence.*;
 import javax.validation.constraints.Size;
 
 import lombok.AccessLevel;
@@ -21,22 +14,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnsweredQuestion {
 
-    @MapsId("surveyId")
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
-    public Survey survey;
-
-    @MapsId("userId")
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    public User user;
-
-    @MapsId("questionBankId")
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_bank_id")
-    public QuestionBank questionBank;
-
     @EmbeddedId
+    @AttributeOverride(name = "answerId", column = @Column(name = "answer_id"))
     private AnsweredQuestionId answeredQuestionId;
 
     @Column(name = "single_choice", nullable = true)
@@ -56,17 +35,14 @@ public class AnsweredQuestion {
     @Builder
     public AnsweredQuestion(Long singleChoice, Long multipleChoice, String shortAnswer,
         String longAnswer, Survey survey, User user, QuestionBank questionBank) {
-        this.user = user;
-        this.survey = survey;
-        this.questionBank = questionBank;
         this.shortAnswer = shortAnswer;
         this.longAnswer = longAnswer;
         this.singleChoice = singleChoice;
         this.multipleChoice = multipleChoice;
         this.answeredQuestionId = AnsweredQuestionId.builder()
-            .surveyId(survey.getSurveyId())
-            .userId(user.getUserId())
-            .questionBankId(questionBank.getQuestionBankId())
+            .survey(survey)
+            .user(user)
+            .questionBank(questionBank)
             .build();
     }
 }

--- a/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestion.java
+++ b/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestion.java
@@ -23,7 +23,7 @@ public class AnsweredQuestion {
 
     @MapsId("surveyId")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "survey_id")
+    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
     public Survey survey;
 
     @MapsId("userId")

--- a/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestionId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/AnsweredQuestionId.java
@@ -4,8 +4,7 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
+import javax.persistence.*;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,23 +16,25 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnsweredQuestionId implements Serializable {
 
-    @Column(name = "answer_id")
     private UUID answerId = UUID.randomUUID();
 
-    @Column(name = "user_id")
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
+    public Survey survey;
 
-    @Column(name = "survey_id")
-    private UUID surveyId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    public User user;
 
-    @Column(name = "question_bank_id")
-    private Long questionBankId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_bank_id")
+    public QuestionBank questionBank;
 
     @Builder
-    public AnsweredQuestionId(Long userId, UUID surveyId, Long questionBankId) {
-        this.userId = userId;
-        this.surveyId = surveyId;
-        this.questionBankId = questionBankId;
+    public AnsweredQuestionId(User user, Survey survey, QuestionBank questionBank) {
+        this.user = user;
+        this.survey = survey;
+        this.questionBank = questionBank;
     }
 
     @Override
@@ -45,13 +46,13 @@ public class AnsweredQuestionId implements Serializable {
             return false;
         }
         AnsweredQuestionId that = (AnsweredQuestionId) o;
-        return Objects.equals(userId, that.userId) && Objects.equals(surveyId, that.surveyId)
-            && Objects.equals(questionBankId, that.questionBankId);
+        return Objects.equals(user, that.user) && Objects.equals(survey, that.survey)
+            && Objects.equals(questionBank, that.questionBank);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId, surveyId, questionBankId);
+        return Objects.hash(user, survey, questionBank);
     }
 
 }

--- a/api/src/main/java/com/thesurvey/api/domain/Participation.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Participation.java
@@ -2,14 +2,7 @@ package com.thesurvey.api.domain;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
@@ -24,17 +17,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participation extends BaseTimeEntity {
 
-    @MapsId("surveyId")
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
-    public Survey survey;
-
-    @MapsId("userId")
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    public User user;
-
     @EmbeddedId
+    @AttributeOverride(name = "certificationType", column = @Column(name = "certification_type", insertable = false, updatable = false))
     private ParticipationId participationId;
 
     @Column(name = "participate_date", nullable = false)
@@ -45,22 +29,16 @@ public class Participation extends BaseTimeEntity {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime submittedDate;
 
-    @Column(name = "certification_type", insertable = false, updatable = false)
-    private CertificationType certificationType;
-
     @Builder
     public Participation(Survey survey, User user,
         LocalDateTime participateDate, LocalDateTime submittedDate,
         CertificationType certificationType) {
-        this.survey = survey;
-        this.user = user;
         this.participateDate = participateDate;
         this.submittedDate = submittedDate;
-        this.certificationType = certificationType;
         this.participationId = ParticipationId.builder()
             .certificationType(certificationType)
-            .surveyId(survey.getSurveyId())
-            .userId(user.getUserId())
+            .survey(survey)
+            .user(user)
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/domain/Participation.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Participation.java
@@ -26,7 +26,7 @@ public class Participation extends BaseTimeEntity {
 
     @MapsId("surveyId")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "survey_id")
+    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
     public Survey survey;
 
     @MapsId("userId")

--- a/api/src/main/java/com/thesurvey/api/domain/ParticipationId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/ParticipationId.java
@@ -4,8 +4,7 @@ import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
+import javax.persistence.*;
 
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import lombok.AccessLevel;
@@ -23,20 +22,21 @@ public class ParticipationId implements Serializable {
      * the value of id : CertificationType
      * 0: NONE, 1: KAKAO, 2: NAVER, 3: GOOGLE, 4: WEBMAIL, 5: DRIVER_LICENSE, 6: IDENTITY_CARD
      */
-    @Column(name = "certification_type")
     private CertificationType certificationType;
 
-    @Column(name = "survey_id")
-    private UUID surveyId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
+    public Survey survey;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    public User user;
 
     @Builder
-    public ParticipationId(CertificationType certificationType, UUID surveyId, Long userId) {
+    public ParticipationId(CertificationType certificationType, Survey survey, User user) {
         this.certificationType = certificationType;
-        this.surveyId = surveyId;
-        this.userId = userId;
+        this.survey = survey;
+        this.user = user;
     }
 
     @Override
@@ -48,11 +48,11 @@ public class ParticipationId implements Serializable {
             return false;
         }
         ParticipationId that = (ParticipationId) o;
-        return Objects.equals(surveyId, that.surveyId) && Objects.equals(userId, that.userId);
+        return Objects.equals(survey, that.survey) && Objects.equals(user, that.user);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(surveyId, userId);
+        return Objects.hash(survey, user);
     }
 }

--- a/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
@@ -2,16 +2,8 @@ package com.thesurvey.api.domain;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
-import javax.persistence.Table;
+import javax.persistence.*;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,16 +16,8 @@ import lombok.NoArgsConstructor;
 public class PointHistory {
 
     @EmbeddedId
+    @AttributeOverride(name = "transactionDate", column = @Column(name = "transaction_date", insertable = false, updatable = false))
     private PointHistoryId pointHistoryId;
-
-    @Column(name = "transaction_date", insertable = false, updatable = false)
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    private LocalDateTime transactionDate;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("userId")
-    @JoinColumn(name = "user_id")
-    private User user;
 
     @Column(name = "point")
     private Integer point;
@@ -42,12 +26,10 @@ public class PointHistory {
 
     @Builder
     public PointHistory(User user, LocalDateTime transactionDate, Integer point) {
-        this.user = user;
         this.point = point;
-        this.transactionDate = transactionDate;
         this.pointHistoryId = PointHistoryId.builder()
             .transactionDate(transactionDate)
-            .userId(user.getUserId())
+            .user(user)
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/domain/PointHistoryId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistoryId.java
@@ -4,8 +4,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
+import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
@@ -18,17 +17,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PointHistoryId implements Serializable {
 
-    @Column(name = "transaction_date")
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime transactionDate;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Builder
-    public PointHistoryId(LocalDateTime transactionDate, Long userId) {
+    public PointHistoryId(LocalDateTime transactionDate, User user) {
         this.transactionDate = transactionDate;
-        this.userId = userId;
+        this.user = user;
     }
 
     @Override
@@ -40,12 +38,12 @@ public class PointHistoryId implements Serializable {
             return false;
         }
         PointHistoryId that = (PointHistoryId) o;
-        return Objects.equals(transactionDate, that.transactionDate) && Objects.equals(userId,
-            that.userId);
+        return Objects.equals(transactionDate, that.transactionDate) && Objects.equals(user,
+            that.user);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(transactionDate, userId);
+        return Objects.hash(transactionDate, user);
     }
 }

--- a/api/src/main/java/com/thesurvey/api/domain/Question.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Question.java
@@ -26,7 +26,7 @@ public class Question {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @MapsId("surveyId")
-    @JoinColumn(name = "survey_id")
+    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
     public Survey survey;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/api/src/main/java/com/thesurvey/api/domain/Question.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Question.java
@@ -1,13 +1,6 @@
 package com.thesurvey.api.domain;
 
-import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
-import javax.persistence.Table;
+import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
@@ -24,16 +17,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("surveyId")
-    @JoinColumn(name = "survey_id", columnDefinition = "uuid")
-    public Survey survey;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("questionBankId")
-    @JoinColumn(name = "question_bank_id")
-    public QuestionBank questionBank;
-
     @EmbeddedId
     private QuestionId questionId;
 
@@ -48,13 +31,11 @@ public class Question {
 
     @Builder
     public Question(QuestionBank questionBank, Survey survey, Integer questionNo, Boolean isRequired) {
-        this.survey = survey;
-        this.questionBank = questionBank;
         this.questionNo = questionNo;
         this.isRequired = isRequired;
         this.questionId = QuestionId.builder()
-            .surveyId(survey.getSurveyId())
-            .questionBankId(questionBank.getQuestionBankId())
+            .survey(survey)
+            .questionBank(questionBank)
             .build();
     }
 

--- a/api/src/main/java/com/thesurvey/api/domain/QuestionBank.java
+++ b/api/src/main/java/com/thesurvey/api/domain/QuestionBank.java
@@ -37,7 +37,7 @@ public class QuestionBank extends BaseTimeEntity {
 
     @Size(min = 1)
     @OneToMany(
-        mappedBy = "questionBank",
+        mappedBy = "questionId.questionBank",
         cascade = CascadeType.PERSIST,
         orphanRemoval = true
     )

--- a/api/src/main/java/com/thesurvey/api/domain/QuestionId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/QuestionId.java
@@ -2,10 +2,8 @@ package com.thesurvey.api.domain;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.UUID;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
+import javax.persistence.*;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,16 +15,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionId implements Serializable {
 
-    @Column(name = "survey_id", columnDefinition = "uuid")
-    private UUID surveyId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id")
+    public Survey survey;
 
-    @Column(name = "question_bank_id")
-    private Long questionBankId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_bank_id")
+    public QuestionBank questionBank;
 
     @Builder
-    public QuestionId(UUID surveyId, Long questionBankId) {
-        this.surveyId = surveyId;
-        this.questionBankId = questionBankId;
+    public QuestionId(Survey survey, QuestionBank questionBank) {
+        this.survey = survey;
+        this.questionBank = questionBank;
     }
 
     @Override
@@ -38,13 +38,13 @@ public class QuestionId implements Serializable {
             return false;
         }
         QuestionId that = (QuestionId) o;
-        return Objects.equals(surveyId, that.surveyId) && Objects.equals(questionBankId,
-            that.questionBankId);
+        return Objects.equals(survey, that.survey) && Objects.equals(questionBank,
+            that.questionBank);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(surveyId, questionBankId);
+        return Objects.hash(survey, questionBank);
     }
 
 }

--- a/api/src/main/java/com/thesurvey/api/domain/Survey.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Survey.java
@@ -38,7 +38,7 @@ public class Survey extends BaseTimeEntity {
     private UUID surveyId;
 
     @OneToMany(
-        mappedBy = "survey",
+        mappedBy = "participationId.survey",
         cascade = CascadeType.ALL,
         orphanRemoval = true
     )
@@ -46,7 +46,7 @@ public class Survey extends BaseTimeEntity {
 
     @Size(min = 1)
     @OneToMany(
-        mappedBy = "survey",
+        mappedBy = "questionId.survey",
         cascade = CascadeType.PERSIST,
         orphanRemoval = true
     )

--- a/api/src/main/java/com/thesurvey/api/domain/User.java
+++ b/api/src/main/java/com/thesurvey/api/domain/User.java
@@ -45,28 +45,28 @@ public class User extends BaseTimeEntity implements UserDetails {
     private Long userId;
 
     @OneToMany(
-        mappedBy = "user",
+        mappedBy = "participationId.user",
         cascade = CascadeType.ALL,
         orphanRemoval = true
     )
     private List<Participation> participations;
 
     @OneToMany(
-        mappedBy = "user",
+        mappedBy = "answeredQuestionId.user",
         cascade = CascadeType.ALL,
         orphanRemoval = true
     )
     private List<AnsweredQuestion> answeredQuestions;
 
     @OneToMany(
-        mappedBy = "user",
+        mappedBy = "userCertificationId.user",
         cascade = CascadeType.ALL,
         orphanRemoval = true
     )
     private List<UserCertification> userCertifications;
 
     @OneToMany(
-        mappedBy = "user",
+        mappedBy = "pointHistoryId.user",
         cascade = CascadeType.ALL,
         orphanRemoval = true
     )

--- a/api/src/main/java/com/thesurvey/api/domain/UserCertification.java
+++ b/api/src/main/java/com/thesurvey/api/domain/UserCertification.java
@@ -5,14 +5,7 @@ import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 
 import java.time.LocalDateTime;
 
-import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.validation.Valid;
+import javax.persistence.*;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,15 +19,8 @@ import lombok.NoArgsConstructor;
 public class UserCertification {
 
     @EmbeddedId
+    @AttributeOverride(name = "certificationType", column = @Column(name = "certification_type", insertable = false, updatable = false))
     private UserCertificationId userCertificationId;
-
-    @Valid
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", insertable = false, updatable = false)
-    private User user;
-
-    @Column(name = "certification_type", insertable = false, updatable = false)
-    private CertificationType certificationType;
 
     @Column(name = "certification_date", nullable = false)
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
@@ -47,11 +33,9 @@ public class UserCertification {
     @Builder
     public UserCertification(User user, CertificationType certificationType,
         LocalDateTime certificationDate, LocalDateTime expirationDate) {
-        this.user = user;
-        this.certificationType = certificationType;
         this.certificationDate = certificationDate;
         this.userCertificationId = UserCertificationId.builder()
-            .userId(user.getUserId())
+            .user(user)
             .certificationType(certificationType)
             .build();
         this.expirationDate = expirationDate;

--- a/api/src/main/java/com/thesurvey/api/domain/UserCertificationId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/UserCertificationId.java
@@ -3,8 +3,8 @@ package com.thesurvey.api.domain;
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import java.io.Serializable;
 import java.util.Objects;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
+import javax.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,20 +15,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserCertificationId implements Serializable {
 
-    @Column(name = "user_id")
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private User user;
 
     /*
      * the value of id is set to the index of EnumTypeEntity.CertificationType.
      * the value of id : CertificationType
      * 0: NONE, 1: KAKAO, 2: NAVER, 3: GOOGLE, 4: WEBMAIL, 5: DRIVER_LICENSE, 6: IDENTITY_CARD
      */
-    @Column(name = "certification_type")
     private CertificationType certificationType;
 
     @Builder
-    public UserCertificationId(Long userId, CertificationType certificationType) {
-        this.userId = userId;
+    public UserCertificationId(User user, CertificationType certificationType) {
+        this.user = user;
         this.certificationType = certificationType;
     }
 
@@ -41,13 +41,13 @@ public class UserCertificationId implements Serializable {
             return false;
         }
         UserCertificationId that = (UserCertificationId) o;
-        return Objects.equals(userId, that.userId) && Objects.equals(certificationType,
-            that.certificationType);
+        return Objects.equals(user, that.user) && Objects.equals(certificationType,
+                that.certificationType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId, certificationType);
+        return Objects.hash(user, certificationType);
     }
 
 }

--- a/api/src/main/java/com/thesurvey/api/repository/AnsweredQuestionRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/AnsweredQuestionRepository.java
@@ -13,19 +13,19 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AnsweredQuestionRepository extends
     JpaRepository<AnsweredQuestion, AnsweredQuestionId> {
-    @Query("SELECT aq FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.surveyId = :surveyId")
+    @Query("SELECT aq FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.survey.surveyId = :surveyId")
     List<AnsweredQuestion> findAllBySurveyId(UUID surveyId);
 
-    @Query("SELECT aq FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.questionBankId = :questionBankId")
+    @Query("SELECT aq FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.questionBank.questionBankId = :questionBankId")
     List<AnsweredQuestion> findAllByQuestionBankId(Long questionBankId);
 
-    @Query("SELECT CASE WHEN COUNT(aq) > 0 THEN true ELSE false END FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.userId = :userId AND aq.answeredQuestionId.surveyId = :surveyId")
+    @Query("SELECT CASE WHEN COUNT(aq) > 0 THEN true ELSE false END FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.user.userId = :userId AND aq.answeredQuestionId.survey.surveyId = :surveyId")
     boolean existsByUserIdAndSurveyId(Long userId, UUID surveyId);
 
-    @Query("SELECT aq.singleChoice, COUNT(aq) FROM AnsweredQuestion aq WHERE aq.questionBank.questionBankId = :questionBankId GROUP BY aq.singleChoice")
+    @Query("SELECT aq.singleChoice, COUNT(aq) FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.questionBank.questionBankId = :questionBankId GROUP BY aq.singleChoice")
     List<Long[]> countSingleChoiceByQuestionBankId(Long questionBankId);
 
-    @Query("SELECT aq.multipleChoice, COUNT(aq) FROM AnsweredQuestion aq WHERE aq.questionBank.questionBankId = :questionBankId GROUP BY aq.multipleChoice")
+    @Query("SELECT aq.multipleChoice, COUNT(aq) FROM AnsweredQuestion aq WHERE aq.answeredQuestionId.questionBank.questionBankId = :questionBankId GROUP BY aq.multipleChoice")
     List<Long[]> countMultipleChoiceByQuestionBankId(Long questionBankId);
 
 }

--- a/api/src/main/java/com/thesurvey/api/repository/ParticipationRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/ParticipationRepository.java
@@ -13,9 +13,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ParticipationRepository extends JpaRepository<Participation, ParticipationId> {
 
-    @Query("SELECT p FROM Participation p WHERE p.survey.surveyId = :surveyId")
+    @Query("SELECT p FROM Participation p WHERE p.participationId.survey.surveyId = :surveyId")
     List<Participation> findAllBySurveyId(UUID surveyId);
 
-    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END FROM Participation p WHERE p.user.userId = :userId AND p.survey.surveyId = :surveyId")
+    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END FROM Participation p WHERE p.participationId.user.userId = :userId AND p.participationId.survey.surveyId = :surveyId")
     boolean existsByUserIdAndSurveyId(Long userId, UUID surveyId);
 }

--- a/api/src/main/java/com/thesurvey/api/repository/PointHistoryRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/PointHistoryRepository.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PointHistoryRepository extends JpaRepository<PointHistory, PointHistoryId> {
 
-    @Query(value = "SELECT ph.point FROM PointHistory ph WHERE ph.user.userId = :userId ORDER BY "
-        + "ph.transactionDate DESC")
+    @Query(value = "SELECT ph.point FROM PointHistory ph WHERE ph.pointHistoryId.user.userId = :userId ORDER BY "
+        + "ph.pointHistoryId.transactionDate DESC")
     List<Integer> findPointHistoryByUserId(@Param("userId") Long userId);
 }

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionBankRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionBankRepository.java
@@ -15,11 +15,10 @@ public interface QuestionBankRepository extends JpaRepository<QuestionBank, Long
 
     Optional<QuestionBank> findByQuestionBankId(Long questionBankId);
 
-    @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.survey s WHERE q"
-        + ".questionId.surveyId= :surveyId ORDER BY q.questionNo ASC")
+    @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.questionId.survey s WHERE s.surveyId= :surveyId ORDER BY q.questionNo ASC")
     List<QuestionBank> findAllBySurveyId(UUID surveyId);
 
-    @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.survey s WHERE q.questionId.surveyId = :surveyId AND qb.title = :title")
+    @Query("SELECT qb FROM QuestionBank qb JOIN FETCH qb.questions q JOIN q.questionId.survey s WHERE s.surveyId = :surveyId AND qb.title = :title")
     Optional<QuestionBank> findBySurveyIdAndTitle(UUID surveyId, String title);
 
 }

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
@@ -14,18 +14,18 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, QuestionId> {
 
-    @Query("SELECT q FROM Question q WHERE q.survey.surveyId = :surveyId ORDER BY q.questionNo ASC")
+    @Query("SELECT q FROM Question q WHERE q.questionId.survey.surveyId = :surveyId ORDER BY q.questionNo ASC")
     List<Question> findAllBySurveyId(UUID surveyId);
 
-    @Query("SELECT q.questionNo FROM Question q WHERE q.questionBank.questionBankId = :questionBankId")
+    @Query("SELECT q.questionNo FROM Question q WHERE q.questionId.questionBank.questionBankId = :questionBankId")
     Optional<Integer> findQuestionNoByQuestionBankId(Long questionBankId);
 
-    @Query("SELECT CASE WHEN COUNT(q) < 0 THEN true ELSE false END FROM Question q WHERE q.questionId.surveyId = :surveyId AND q.questionId.questionBankId = :questionBankId")
+    @Query("SELECT CASE WHEN COUNT(q) < 0 THEN true ELSE false END FROM Question q WHERE q.questionId.survey.surveyId = :surveyId AND q.questionId.questionBank.questionBankId = :questionBankId")
     boolean notExistsBySurveyIdAndQuestionBankId(UUID surveyId, Long questionBankId);
 
-    @Query("SELECT q FROM Question q WHERE q.questionBank.questionBankId = :questionBankId")
+    @Query("SELECT q FROM Question q WHERE q.questionId.questionBank.questionBankId = :questionBankId")
     Optional<Question> findByQuestionBankId(Long questionBankId);
 
-    @Query("SELECT q.isRequired FROM Question q WHERE q.questionBank.questionBankId = :questionBankId")
+    @Query("SELECT q.isRequired FROM Question q WHERE q.questionId.questionBank.questionBankId = :questionBankId")
     Optional<Boolean> findIsRequiredByQuestionBankId(Long questionBankId);
 }

--- a/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/SurveyRepository.java
@@ -20,7 +20,7 @@ public interface SurveyRepository extends JpaRepository<Survey, UUID> {
     @Query("SELECT s FROM Survey s WHERE s.endedDate > CURRENT_TIMESTAMP ORDER BY s.createdDate DESC")
     Page<Survey> findAllInDescendingOrder(Pageable pageable);
 
-    @Query("SELECT p.certificationType FROM Participation p WHERE p.survey.surveyId = :surveyId AND p.user.userId = :authorId")
+    @Query("SELECT p.participationId.certificationType FROM Participation p WHERE p.participationId.survey.surveyId = :surveyId AND p.participationId.user.userId = :authorId")
     List<Integer> findCertificationTypeBySurveyIdAndAuthorId(@Param("surveyId") UUID surveyId, @Param("authorId") Long authorId);
 
     Optional<Survey> findBySurveyId(UUID surveyId);

--- a/api/src/main/java/com/thesurvey/api/repository/UserCertificationRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/UserCertificationRepository.java
@@ -11,10 +11,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserCertificationRepository extends JpaRepository<UserCertification, Long> {
 
-    @Query("SELECT uc.certificationType FROM UserCertification uc WHERE uc.userCertificationId.userId = :userId")
+    @Query("SELECT uc.userCertificationId.certificationType FROM UserCertification uc WHERE uc.userCertificationId.user.userId = :userId")
     List<Integer> findUserCertificationTypeByUserId(Long userId);
 
-    @Query("SELECT uc FROM UserCertification uc WHERE uc.userCertificationId.userId = :userId")
+    @Query("SELECT uc FROM UserCertification uc WHERE uc.userCertificationId.user.userId = :userId")
     List<UserCertification> findUserCertificationByUserId(Long userId);
 
     void deleteByExpirationDateLessThanEqual(LocalDateTime nowDate);

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -187,13 +187,13 @@ public class SurveyService {
             throw new BadRequestExceptionMapper(ErrorMessage.SURVEY_ALREADY_STARTED);
         }
 
-        answeredQuestionService.deleteAnswer(surveyId);
-        surveyRepository.delete(survey);
-        participationService.deleteParticipation(surveyId);
-        questionService.deleteQuestion(surveyId);
-
         int surveyCreatePoints = pointUtil.calculateSurveyCreatePoints(survey.getSurveyId());
         pointHistoryService.savePointHistory(user, surveyCreatePoints);
+        participationService.deleteParticipation(surveyId);
+        answeredQuestionService.deleteAnswer(surveyId);
+        questionService.deleteQuestion(surveyId);
+        surveyRepository.delete(survey);
+
     }
 
     @Transactional

--- a/api/src/main/java/com/thesurvey/api/service/mapper/UserCertificationMapper.java
+++ b/api/src/main/java/com/thesurvey/api/service/mapper/UserCertificationMapper.java
@@ -27,7 +27,7 @@ public class UserCertificationMapper {
 
         List<CertificationInfo<CertificationType>> certificationInfoList = new ArrayList<>();
         for (UserCertification userCertification : userCertificationList) {
-            CertificationType certificationType = userCertification.getCertificationType();
+            CertificationType certificationType = userCertification.getUserCertificationId().getCertificationType();
             certificationInfoList.add(getCertificationInfo(certificationType, userCertification.getExpirationDate()));
         }
         return UserCertificationListDto.builder()

--- a/api/src/main/resources/application-test.yml
+++ b/api/src/main/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+      url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+      driverClassName: org.h2.Driver
+      username: sa
+      password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+logging:
+  level:
+    org.hibernate.sql: info

--- a/api/src/test/java/com/thesurvey/api/ApiApplicationTests.java
+++ b/api/src/test/java/com/thesurvey/api/ApiApplicationTests.java
@@ -3,8 +3,10 @@ package com.thesurvey.api;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ApiApplicationTests {
 
     @Test

--- a/api/src/test/java/com/thesurvey/api/controller/AuthenticationControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/AuthenticationControllerTest.java
@@ -22,12 +22,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional
 @AutoConfigureMockMvc
 @TestInstance(Lifecycle.PER_CLASS)

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -51,6 +51,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,6 +64,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional
 @TestInstance(Lifecycle.PER_CLASS)
 @AutoConfigureMockMvc

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -384,8 +384,6 @@ public class SurveyControllerTest extends BaseControllerTest {
         Long userId = UserUtil.getUserIdFromAuthentication(authentication);
 
         // when
-        // FIXME: deleting survey twice works fine but this is not the expected one.
-        surveyService.deleteSurvey(authentication, surveyId);
         mockMvc.perform(delete("/surveys/" + surveyId)).andExpect(status().isNoContent());
 
         // then

--- a/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/UserControllerTest.java
@@ -36,6 +36,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +49,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional
 @AutoConfigureMockMvc
 @TestInstance(Lifecycle.PER_CLASS)

--- a/api/src/test/java/com/thesurvey/api/service/AnsweredQuestionServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/AnsweredQuestionServiceTest.java
@@ -28,10 +28,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @TestInstance(value = Lifecycle.PER_CLASS)
 public class AnsweredQuestionServiceTest {
 

--- a/api/src/test/java/com/thesurvey/api/service/AuthenticationServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/AuthenticationServiceTest.java
@@ -13,11 +13,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional
 @AutoConfigureMockMvc
 @TestInstance(Lifecycle.PER_CLASS)

--- a/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
@@ -32,11 +32,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @TestInstance(Lifecycle.PER_CLASS)
 public class PointHistoryServiceTest {
 

--- a/api/src/test/java/com/thesurvey/api/service/UserCertificationServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/UserCertificationServiceTest.java
@@ -15,12 +15,14 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 public class UserCertificationServiceTest {
 
     @Autowired


### PR DESCRIPTION
이 Pull Request는 기존 PostgreSQL DB 서버를 필요로 하는 테스트 환경을 H2 in-memory DB 기반 환경으로 구성합니다. 

### 추가 사항 

- h2 database 의존성을 추가했습니다.
- 테스트를 위한 `application-test.yml` 프로필을 추가했습니다. 

### 수정 사항

- Join 테이블과 매핑되는 클래스 (e.g. `Question`) 에서 **Survey** 엔티티 `@JoinColumn` 옵션으로 `columnDefinition = "uuid"` 을 추가했습니다.
- `@Embeddable` 클래스를 리팩토링 하여, 복합키를 사용하는 엔티티가 Foreign key의 Constraint를 따르도록 하였습니다. 
이전 구현에 경우, surveyId가 H2 DB에서 BINARY(255)로 타입이 CAST 되고 있었습니다. 

이는 hibernate가 DB와 매핑하기 위하여 ORM을 진행할 때, UUID를 BINARY 배열로 저장하는 것을 기본으로 하고 있기 때문입니다.
따라서 명시적으로 h2 DB에서 사용하는 UUID 타입으로 캐스팅 하도록 해주어야 합니다.
자세한 내용은 [Hibernate 공식 문서](https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html#basic-uuid) 참조할 수 있으며, 문제 해결 과정을 [블로그](https://bezzang2.tistory.com/176)에 기록해두었습니다.

- DB 연결을 필요로 하는 테스트에 대해 `@ActiveProfiles("test")` 어노테이션을 적용하였습니다.


