### PR TITLE
add: 테스트 실패 케이스(uuid 관련)

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/api/src/main/java/com/thesurvey/api/domain/QuestionTest.java
+++ b/api/src/main/java/com/thesurvey/api/domain/QuestionTest.java
@@ -1,0 +1,33 @@
+package com.thesurvey.api.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "question_test")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionTest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", columnDefinition = "BINARY(20)")
+    public Survey survey;
+
+    @Column(name = "question_no")
+    private Integer questionNo;
+
+    @Column(name = "is_required")
+    private Boolean isRequired;
+
+    @Builder
+    public QuestionTest(Integer questionNo, Boolean isRequired, Survey survey) {
+        this.questionNo = questionNo;
+        this.isRequired = isRequired;
+        this.survey = survey;
+    }
+}

--- a/api/src/main/java/com/thesurvey/api/domain/Survey.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Survey.java
@@ -52,29 +52,20 @@ public class Survey extends BaseTimeEntity {
     )
     private List<Question> questions;
 
-    @NotNull
-    @Positive
-    @Column(name = "author_id", updatable = false, nullable = false)
+    @Column(name = "author_id", updatable = false)
     private Long authorId;
 
-    @NotBlank
-    @Size(max = 100)
-    @Column(name = "title", nullable = false)
+    @Column(name = "title")
     private String title;
 
-    @NotBlank
-    @Size(max = 255)
     @Column(name = "description", nullable = true)
     private String description;
 
-    @NotNull
-    @Column(name = "started_date", nullable = false)
+    @Column(name = "started_date")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startedDate;
 
-    @NotNull
-    @Future
-    @Column(name = "ended_date", nullable = false)
+    @Column(name = "ended_date")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime endedDate;
 

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionTestRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionTestRepository.java
@@ -1,0 +1,9 @@
+package com.thesurvey.api.repository;
+
+import com.thesurvey.api.domain.QuestionTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionTestRepository extends JpaRepository<QuestionTest, Long> {
+}

--- a/api/src/main/resources/application-test.yml
+++ b/api/src/main/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+logging:
+  level:
+    org.hibernate.SQL: debug

--- a/api/src/test/java/com/thesurvey/api/repository/QuestionTestRepositoryTest.java
+++ b/api/src/test/java/com/thesurvey/api/repository/QuestionTestRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.thesurvey.api.repository;
+
+import com.thesurvey.api.domain.QuestionTest;
+import com.thesurvey.api.domain.Survey;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class QuestionTestRepositoryTest {
+    @Autowired
+    SurveyRepository surveyRepository;
+
+    @Autowired
+    QuestionTestRepository questionTestRepository;
+
+    @Test
+    void testCreate(){
+        Survey survey = surveyRepository.save(Survey.builder().build());
+
+        QuestionTest given = QuestionTest.builder()
+                .survey(survey)
+                .build();
+
+        questionTestRepository.save(given);
+    }
+
+}


### PR DESCRIPTION
## 개요
uuid 관련 실패케이스 건으로, 한번 살펴보면 좋겠다 싶어서 PR 드렸습니다.
제가 추가한 테스트 케이스는 왜 실패하는지 한번 살펴보시면 좋을 것 같습니다. (힌트: jpa foreign key constraint)


## 생각해볼 것들
* QuestionTest 엔티티의 survey_id 를 columnDefinition 을  BINARY(16) 으로 바꾸면 왜 테스트가 통과할까요?
* jpa 에서 엔티티에 `@JoinColumn` 선언 시 기본으로 설정되는 constraint는 무엇일까요? 
* postgre dialect 는 어떻게 설정될까요? 


## 그 외
<img width="543" alt="image" src="https://github.com/kimjinmyeong/the-survey-revision/assets/24622029/a946e875-bf89-4b96-ab28-07b0ae2c34ae"> 

QuestionId 는 Question 엔티티의 복합키로 사용되고 있는데, `@Column` 어노테이션이 필요할까요?