### PR TITLE
refactor: fetch `Authentication` from SecurityContext

### DIFF
--- a/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
@@ -60,9 +60,8 @@ public class SurveyController {
         @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/{surveyId}")
-    public ResponseEntity<SurveyResponseDto> getSurvey(
-        @Parameter(hidden = true) Authentication authentication, @PathVariable Long surveyId) {
-        return ResponseEntity.ok(surveyService.getSurveyBySurveyIdWithRelatedQuestion(authentication, surveyId));
+    public ResponseEntity<SurveyResponseDto> getSurvey(@PathVariable Long surveyId) {
+        return ResponseEntity.ok(surveyService.getSurveyBySurveyIdWithRelatedQuestion(surveyId));
     }
 
     @Operation(summary = "설문조사 생성", description = "새로운 설문조사를 생성합니다.")
@@ -75,10 +74,8 @@ public class SurveyController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping
-    public ResponseEntity<SurveyResponseDto> createSurvey(
-        @Parameter(hidden = true) Authentication authentication,
-        @Valid @RequestBody SurveyRequestDto surveyRequestDto) {
-        return ResponseEntity.ok(surveyService.createSurvey(authentication, surveyRequestDto));
+    public ResponseEntity<SurveyResponseDto> createSurvey(@Valid @RequestBody SurveyRequestDto surveyRequestDto) {
+        return ResponseEntity.ok(surveyService.createSurvey(surveyRequestDto));
     }
 
     @Operation(summary = "설문조사 수정", description = "설문조사 내용을 수정합니다.")
@@ -92,10 +89,9 @@ public class SurveyController {
     })
     @PatchMapping
     public ResponseEntity<SurveyResponseDto> updateSurvey(
-        @Parameter(hidden = true) Authentication authentication,
         @Valid @RequestBody SurveyUpdateRequestDto surveyUpdateRequestDto) {
         return ResponseEntity.ok(
-            surveyService.updateSurvey(authentication, surveyUpdateRequestDto));
+            surveyService.updateSurvey(surveyUpdateRequestDto));
     }
 
     @Operation(summary = "설문조사 삭제", description = "파라미터로 전달 받은 UUID에 해당하는 설문조사를 삭제합니다.")
@@ -124,10 +120,9 @@ public class SurveyController {
     })
     @PostMapping("/submit")
     public ResponseEntity<AnsweredQuestionRewardPointDto> submitSurvey(
-        @Parameter(hidden = true) Authentication authentication,
-        @Valid @RequestBody AnsweredQuestionRequestDto answeredQuestionRequestDto) {
+            @Valid @RequestBody AnsweredQuestionRequestDto answeredQuestionRequestDto) {
         AnsweredQuestionRewardPointDto rewardPointDto =
-            answeredQuestionService.createAnswer(authentication, answeredQuestionRequestDto);
+            answeredQuestionService.createAnswer(answeredQuestionRequestDto);
         return ResponseEntity.ok(rewardPointDto);
     }
 

--- a/api/src/main/java/com/thesurvey/api/controller/UserController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/UserController.java
@@ -79,11 +79,9 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/surveys/{surveyId}")
-    public ResponseEntity<UserSurveyResultDto> getUserCreatedSurveyResult(
-            @Parameter(hidden = true) Authentication authentication,
-            @PathVariable("surveyId") Long surveyId) {
+    public ResponseEntity<UserSurveyResultDto> getUserCreatedSurveyResult(@PathVariable("surveyId") Long surveyId) {
         return ResponseEntity.ok(
-                surveyService.getUserCreatedSurveyResult(authentication, surveyId));
+                surveyService.getUserCreatedSurveyResult(surveyId));
     }
 
     @Operation(summary = "사용자 정보 수정", description = "요청한 사용자의 정보를 수정합니다.")
@@ -95,11 +93,9 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @PatchMapping("/profile")
-    public ResponseEntity<UserResponseDto> updateUserProfile(
-            @Parameter(hidden = true) Authentication authentication,
-            @RequestBody UserUpdateRequestDto userUpdateRequestDto) {
+    public ResponseEntity<UserResponseDto> updateUserProfile(@RequestBody UserUpdateRequestDto userUpdateRequestDto) {
         return ResponseEntity.ok(
-                userService.updateUserProfile(authentication, userUpdateRequestDto));
+                userService.updateUserProfile(userUpdateRequestDto));
     }
 
     @Operation(summary = "사용자 인증 정보 조회", description = "사용자의 인증 정보를 조회합니다.")
@@ -111,10 +107,8 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "요청한 리소스 찾을 수 없음", content = @Content(schema = @Schema(hidden = true)))
     })
     @GetMapping("/profile/certifications")
-    public ResponseEntity<UserCertificationListDto> getUserCertification(
-            @Parameter(hidden = true) Authentication authentication) {
-        return ResponseEntity.ok(
-                userCertificationService.getUserCertifications(authentication));
+    public ResponseEntity<UserCertificationListDto> getUserCertification() {
+        return ResponseEntity.ok(userCertificationService.getUserCertifications());
     }
 
     @Operation(summary = "사용자 인증 정보 수정", description = "사용자의 인증 정보를 수정합니다.")

--- a/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/AnsweredQuestionService.java
@@ -18,6 +18,7 @@ import com.thesurvey.api.util.StringUtil;
 import com.thesurvey.api.util.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,8 +69,8 @@ public class AnsweredQuestionService {
     }
 
     @Transactional
-    public AnsweredQuestionRewardPointDto createAnswer(Authentication authentication,
-                                                       AnsweredQuestionRequestDto answeredQuestionRequestDto) {
+    public AnsweredQuestionRewardPointDto createAnswer(AnsweredQuestionRequestDto answeredQuestionRequestDto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         User user = UserUtil.getUserFromAuthentication(authentication);
         Survey survey = surveyRepository.findBySurveyId(answeredQuestionRequestDto.getSurveyId())
                 .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.SURVEY_NOT_FOUND));

--- a/api/src/main/java/com/thesurvey/api/service/SurveyService.java
+++ b/api/src/main/java/com/thesurvey/api/service/SurveyService.java
@@ -31,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,10 +86,9 @@ public class SurveyService {
     }
 
     @Transactional(readOnly = true)
-    public SurveyResponseDto getSurveyBySurveyIdWithRelatedQuestion(Authentication authentication
-        , Long surveyId) {
+    public SurveyResponseDto getSurveyBySurveyIdWithRelatedQuestion(Long surveyId) {
         Survey survey = getSurveyFromSurveyId(surveyId);
-
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         List<Integer> surveyCertificationList =
             surveyRepository.findCertificationTypeBySurveyIdAndAuthorId(surveyId, survey.getAuthorId());
         Long userId = UserUtil.getUserIdFromAuthentication(authentication);
@@ -115,16 +115,16 @@ public class SurveyService {
     /**
      * Returns survey results and the answers created by the user.
      *
-     * @param authentication authentication of the requesting user
      * @param surveyId the ID of survey to get result
      * @return {@link UserSurveyResultDto}
      */
     @Transactional(readOnly = true)
-    public UserSurveyResultDto getUserCreatedSurveyResult(Authentication authentication,
-        Long surveyId) {
+    public UserSurveyResultDto getUserCreatedSurveyResult(Long surveyId) {
         Survey survey = getSurveyFromSurveyId(surveyId);
 
         // validate survey author from current user
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         validateSurveyAuthor(UserUtil.getUserIdFromAuthentication(authentication),
             survey.getAuthorId());
 
@@ -141,8 +141,7 @@ public class SurveyService {
     }
 
     @Transactional
-    public SurveyResponseDto createSurvey(Authentication authentication,
-        SurveyRequestDto surveyRequestDto) {
+    public SurveyResponseDto createSurvey(SurveyRequestDto surveyRequestDto) {
 
         // `startedDate` is only allowed to be within 5 seconds from now or later.
         if (surveyRequestDto.getStartedDate()
@@ -154,6 +153,8 @@ public class SurveyService {
         if (surveyRequestDto.getStartedDate().isAfter(surveyRequestDto.getEndedDate())) {
             throw new BadRequestExceptionMapper(ErrorMessage.STARTEDDATE_ISAFTER_ENDEDDATE);
         }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         User user = UserUtil.getUserFromAuthentication(authentication);
 
         List<CertificationType> certificationTypes =
@@ -196,8 +197,8 @@ public class SurveyService {
     }
 
     @Transactional
-    public SurveyResponseDto updateSurvey(Authentication authentication,
-        SurveyUpdateRequestDto surveyUpdateRequestDto) {
+    public SurveyResponseDto updateSurvey(SurveyUpdateRequestDto surveyUpdateRequestDto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = UserUtil.getUserIdFromAuthentication(authentication);
         Survey survey = getSurveyFromSurveyId(surveyUpdateRequestDto.getSurveyId());
 

--- a/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
+++ b/api/src/main/java/com/thesurvey/api/service/UserCertificationService.java
@@ -11,6 +11,7 @@ import com.thesurvey.api.util.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +28,8 @@ public class UserCertificationService {
     private final UserCertificationMapper userCertificationMapper;
 
     @Transactional(readOnly = true)
-    public UserCertificationListDto getUserCertifications(Authentication authentication) {
+    public UserCertificationListDto getUserCertifications() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = UserUtil.getUserIdFromAuthentication(authentication);
         return userCertificationMapper.toUserCertificationListDto(userId);
     }

--- a/api/src/main/java/com/thesurvey/api/service/UserService.java
+++ b/api/src/main/java/com/thesurvey/api/service/UserService.java
@@ -12,6 +12,7 @@ import com.thesurvey.api.util.UserUtil;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,8 +37,8 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponseDto updateUserProfile(Authentication authentication,
-        UserUpdateRequestDto userUpdateRequestDto) {
+    public UserResponseDto updateUserProfile(UserUpdateRequestDto userUpdateRequestDto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         User user = UserUtil.getUserFromAuthentication(authentication);
 
         if (userUpdateRequestDto.getPassword() != null) {

--- a/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
+++ b/api/src/test/java/com/thesurvey/api/controller/SurveyControllerTest.java
@@ -37,6 +37,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -163,9 +164,11 @@ public class SurveyControllerTest extends BaseControllerTest {
             new UsernamePasswordAuthenticationToken(userLoginRequestDto.getEmail(),
                 userLoginRequestDto.getPassword())
         );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         MvcResult createdSurvey = mockCreateSurvey(surveyRequestDto);
         mockSurvey = new JSONObject(createdSurvey.getResponse().getContentAsString());
+
     }
 
     @Test

--- a/api/src/test/java/com/thesurvey/api/service/AnsweredQuestionServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/AnsweredQuestionServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
@@ -89,6 +90,7 @@ public class AnsweredQuestionServiceTest {
         submitUserAuthentication = authenticationService.authenticate(
             new UsernamePasswordAuthenticationToken(submitUserRegisterRequestDto.getEmail(),
                 submitUserRegisterRequestDto.getPassword()));
+
     }
 
     @Test
@@ -116,8 +118,8 @@ public class AnsweredQuestionServiceTest {
             .questions(testQuestionList)
             .build();
 
-        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(testAuthentication,
-            testSurveyRequestDto);
+        SecurityContextHolder.getContext().setAuthentication(testAuthentication);
+        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(testSurveyRequestDto);
         List<QuestionBankResponseDto> testQuestionResponseList = testSurveyResponseDto.getQuestions();
 
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
@@ -133,8 +135,7 @@ public class AnsweredQuestionServiceTest {
             .build();
 
         assertThrows(UnauthorizedRequestExceptionMapper.class,
-            () -> answeredQuestionService.createAnswer(submitUserAuthentication,
-                answeredQuestionRequestDto));
+            () -> answeredQuestionService.createAnswer(answeredQuestionRequestDto));
     }
 
     @Test
@@ -187,9 +188,8 @@ public class AnsweredQuestionServiceTest {
             .certificationTypes(List.of(CertificationType.NONE))
             .questions(testQuestionList)
             .build();
-
-        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(testAuthentication,
-            testSurveyRequestDto);
+        SecurityContextHolder.getContext().setAuthentication(testAuthentication);
+        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(testSurveyRequestDto);
         List<QuestionBankResponseDto> testQuestionResponseList = testSurveyResponseDto.getQuestions();
 
         AnsweredQuestionDto longAnsweredQuestionDto = AnsweredQuestionDto.builder()
@@ -226,9 +226,10 @@ public class AnsweredQuestionServiceTest {
                 singleChoiceAnsweredQuestion, multipleChoicesAnsweredQuestion))
             .build();
 
+
+        SecurityContextHolder.getContext().setAuthentication(submitUserAuthentication);
         assertThrows(BadRequestExceptionMapper.class,
-            () -> answeredQuestionService.createAnswer(submitUserAuthentication,
-                answeredQuestionRequestDto));
+            () -> answeredQuestionService.createAnswer(answeredQuestionRequestDto));
     }
 
 }

--- a/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/PointHistoryServiceTest.java
@@ -1,11 +1,5 @@
 package com.thesurvey.api.service;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import com.thesurvey.api.domain.EnumTypeEntity.PointTransactionType;
 import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
@@ -27,12 +21,18 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -112,9 +112,10 @@ public class PointHistoryServiceTest {
             new UsernamePasswordAuthenticationToken(userRegisterRequestDto.getEmail(),
                 userRegisterRequestDto.getPassword())
         );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         assertThrows(BadRequestExceptionMapper.class,
-            () -> surveyService.createSurvey(authentication,
-                surveyRequestDto));
+            () -> surveyService.createSurvey(surveyRequestDto));
     }
 
     @Test
@@ -182,8 +183,10 @@ public class PointHistoryServiceTest {
                 userRegisterRequestDto.getPassword())
         );
 
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         // when
-        surveyService.createSurvey(authentication, surveyRequestDto);
+        surveyService.createSurvey(surveyRequestDto);
 
         // then
         assertEquals(pointHistoryService.getUserTotalPoint(testUserResponseDto.getUserId()),
@@ -230,9 +233,9 @@ public class PointHistoryServiceTest {
             new UsernamePasswordAuthenticationToken(userRegisterRequestDto.getEmail(),
                 userRegisterRequestDto.getPassword())
         );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(authentication,
-            surveyRequestDto);
+        SurveyResponseDto testSurveyResponseDto = surveyService.createSurvey(surveyRequestDto);
 
         List<QuestionBankResponseDto> testQuestionResponseList =
             testSurveyResponseDto.getQuestions();
@@ -250,6 +253,7 @@ public class PointHistoryServiceTest {
         Authentication submitUserAuthentication = authenticationService.authenticate(
             new UsernamePasswordAuthenticationToken(submitUserRequestDto.getEmail(),
                 submitUserRequestDto.getPassword()));
+        SecurityContextHolder.getContext().setAuthentication(submitUserAuthentication);
 
         AnsweredQuestionDto answeredQuestionDto = AnsweredQuestionDto.builder()
             .questionBankId(testQuestionResponseList.get(0).getQuestionBankId())
@@ -264,7 +268,7 @@ public class PointHistoryServiceTest {
             .build();
 
         // when
-        answeredQuestionService.createAnswer(submitUserAuthentication, answeredQuestionRequestDto);
+        answeredQuestionService.createAnswer(answeredQuestionRequestDto);
 
         // then
         assertEquals(pointHistoryService.getUserTotalPoint(submitUserResponseDto.getUserId()),

--- a/api/src/test/java/com/thesurvey/api/service/SurveyServiceTest.java
+++ b/api/src/test/java/com/thesurvey/api/service/SurveyServiceTest.java
@@ -1,9 +1,5 @@
 package com.thesurvey.api.service;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
-
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
 import com.thesurvey.api.domain.EnumTypeEntity.QuestionType;
 import com.thesurvey.api.domain.Survey;
@@ -25,11 +21,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -134,7 +133,7 @@ public class SurveyServiceTest {
             .build();
 
         assertThrows(BadRequestExceptionMapper.class,
-            () -> surveyService.createSurvey(fakeAuthentication, surveyRequestDto));
+            () -> surveyService.createSurvey(surveyRequestDto));
     }
 
     /**
@@ -201,7 +200,7 @@ public class SurveyServiceTest {
             .build();
 
         assertThrows(BadRequestExceptionMapper.class,
-            () -> surveyService.createSurvey(fakeAuthentication, surveyRequestDto));
+            () -> surveyService.createSurvey(surveyRequestDto));
         assertThrows(BadRequestExceptionMapper.class,
             () -> surveyService.validateUpdateSurvey(survey, surveyUpdateRequestDto));
     }


### PR DESCRIPTION
Authentication은 SecurityContextHolder에 저장되며, SecurityContext는 ThreadLocal에 저장되기 때문에 각 스레드마다 고유한 Authentication을 저장하게 됩니다.
`SecurityContextHolder.getContext().getAuthentication()` 함수를 통해 Authentication을 얻을 수 있는데, 이는 Thread-safe 하며
메서드 파라미터로 Authentication을 Spring Securiy에게 주입받고 메서드마다 전달하는 것은 함수가 외부 파라미터에 대한 의존성을 높일 수 있고, 가독성에 좋지 않다고 판단하여 파라미터로 Authentication을 넘기는 방식 대신 SecurityContextHolder에서 가져오도록 수정하였습니다.
