### PR TITLE
feat: Redis 설정 추가 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation 'org.postgresql:postgresql'
+    implementation 'org.redisson:redisson:3.31.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/api/src/main/java/com/thesurvey/api/config/RedissonConfig.java
+++ b/api/src/main/java/com/thesurvey/api/config/RedissonConfig.java
@@ -1,0 +1,23 @@
+package com.thesurvey.api.config;
+
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.Redisson;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://127.0.0.1:6379");
+//        config.useSentinelServers()
+//                .setMasterName("mymaster")
+//                .addSentinelAddress("redis://127.0.0.1:26379", "redis://127.0.0.1:26380", "redis://127.0.0.1:26381");
+
+        return Redisson.create(config);
+    }
+}

--- a/api/src/test/java/com/thesurvey/api/RedissonConfigTest.java
+++ b/api/src/test/java/com/thesurvey/api/RedissonConfigTest.java
@@ -1,0 +1,31 @@
+package com.thesurvey.api;
+
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class RedissonConfigTest {
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Test
+    public void testRedissonClient() {
+        // Ensure the RedissonClient is not null
+        assertThat(redissonClient).isNotNull();
+
+        RBucket<String> bucket = redissonClient.getBucket("testKey");
+        bucket.set("testValue");
+
+        String value = bucket.get();
+        assertThat(value).isEqualTo("testValue");
+
+        // Clean up
+        bucket.delete();
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,17 @@ services:
   #   ports:
   #     - 3000:3000
 
+  #  api:
+  #    container_name: api
+  #    build: ./api
+  #    network_mode: bridge
+  #    ports:
+  #      - 8080:8080
+  #    restart: unless-stopped
+  #    depends_on:
+  #      - db
+  #    links:
+  #      - db
   db:
     container_name: db
     image: postgres:14-alpine
@@ -17,22 +28,113 @@ services:
     ports:
       - 5432:5432
     environment:
-         - POSTGRES_PASSWORD=the_survey_dev
-         - POSTGRES_USER=the_survey_dev
-         - POSTGRES_DB=the_survey_dev
+      - POSTGRES_PASSWORD=the_survey_revision
+      - POSTGRES_USER=the_survey_revision
+      - POSTGRES_DB=the_survey_revision
     restart: unless-stopped
 
-  api:
-    container_name: api
-    build: ./api
-    network_mode: bridge
+  redis-master:
+    container_name: redis-master
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=master
+      - ALLOW_EMPTY_PASSWORD=yes
+    networks:
+      - redis-network
     ports:
-      - 8080:8080
-    restart: unless-stopped
+      - '6379:6379'
+
+  redis-slave-1:
+    container_name: redis-slave-1
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=redis-master
+      - ALLOW_EMPTY_PASSWORD=yes
     depends_on:
-      - db
-    links:
-      - db
+      - redis-master
+    networks:
+      - redis-network
+    ports:
+      - '6380:6379'
+
+  redis-slave-2:
+    container_name: redis-slave-2
+    image: 'bitnami/redis:latest'
+    environment:
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=redis-master
+      - ALLOW_EMPTY_PASSWORD=yes
+    depends_on:
+      - redis-master
+    networks:
+      - redis-network
+    ports:
+      - '6381:6379'
+
+  redis-sentinel-1:
+    container_name: redis-sentinel-1
+    image: 'bitnami/redis-sentinel:latest'
+    environment:
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=5000
+      - REDIS_SENTINEL_FAILOVER_TIMEOUT=60000
+      - REDIS_SENTINEL_PARALLEL_SYNCS=1
+      - REDIS_MASTER_HOST=redis-master
+      - REDIS_MASTER_PORT_NUMBER=6379
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+    depends_on:
+      - redis-master
+      - redis-slave-1
+      - redis-slave-2
+    networks:
+      - redis-network
+    ports:
+      - '26379:26379'
+
+  redis-sentinel-2:
+    container_name: redis-sentinel-2
+    image: 'bitnami/redis-sentinel:latest'
+    environment:
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=5000
+      - REDIS_SENTINEL_FAILOVER_TIMEOUT=60000
+      - REDIS_SENTINEL_PARALLEL_SYNCS=1
+      - REDIS_MASTER_HOST=redis-master
+      - REDIS_MASTER_PORT_NUMBER=6379
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+    depends_on:
+      - redis-master
+      - redis-slave-1
+      - redis-slave-2
+    networks:
+      - redis-network
+    ports:
+      - '26380:26379'
+
+  redis-sentinel-3:
+    container_name: redis-sentinel-3
+    image: 'bitnami/redis-sentinel:latest'
+    environment:
+      - REDIS_SENTINEL_DOWN_AFTER_MILLISECONDS=5000
+      - REDIS_SENTINEL_FAILOVER_TIMEOUT=60000
+      - REDIS_SENTINEL_PARALLEL_SYNCS=1
+      - REDIS_MASTER_HOST=redis-master
+      - REDIS_MASTER_PORT_NUMBER=6379
+      - REDIS_MASTER_SET=mymaster
+      - REDIS_SENTINEL_QUORUM=2
+    depends_on:
+      - redis-master
+      - redis-slave-1
+      - redis-slave-2
+    networks:
+      - redis-network
+    ports:
+      - '26381:26379'
+
+networks:
+  redis-network:
+    driver: bridge
 
 volumes:
   postgres: {}


### PR DESCRIPTION
이 PR은 Redis를 추가합니다.
또한 Redis Sentinel을 구성했지만, 테스트가 무한 로딩에 걸리는 문제가 생겨서 일단 Single Server로 동작하게끔 RedissonConfig 클래스를 구현했습니다.

Redis Sentinel은 1개의 master, 2개의 slave, 3개의 sentinel로 구성됩니다.

### 추가 사항 

- Redis Sentinel 클러스터 설정 추가
- Redisson 설정 클래스 추가
- Redisson 클라이언트 테스트 클래스 추가
- Docker Compose 파일 수정

### 변경된 파일 목록

1. `api/src/main/java/com/thesurvey/api/config/RedissonConfig.java`
   - Redisson을 사용한 Redis Sentinel 설정 추가

2. `api/src/test/java/com/thesurvey/api/RedissonConfigTest.java`
   - Redisson 클라이언트 설정 및 동작 테스트

3. `docker-compose.yml`
   - Redis Master, Slave, Sentinel 컨테이너 정의 및 설정
