### PR TITLE
feat: Gatling BaseSimulation, Submit Survey Scenario 추가, HikariCP 값 수정

### DIFF
--- a/api/src/gatling/java/simulations/BaseSimulation.java
+++ b/api/src/gatling/java/simulations/BaseSimulation.java
@@ -1,0 +1,64 @@
+package simulations;
+
+import io.gatling.javaapi.core.Simulation;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static io.gatling.javaapi.http.HttpDsl.http;
+
+/**
+ * Abstract base class for Gatling performance simulations.
+ * This class provides common setup for HTTP protocol, headers, and a feeder iterator.
+ * Subclasses should implement the specific test setups for load, stress, and soak testing.
+ *
+ * To run the simulation with a specified test type, use the following command:
+ *
+ * <pre>
+ * ./gradlew gatlingRun-SimulationClassName -Dtype=LOAD
+ * ./gradlew gatlingRun-SimulationClassName -Dtype=STRESS
+ * ./gradlew gatlingRun-SimulationClassName -Dtype=SOAK
+ * </pre>
+ *
+ * Replace `SimulationClassName` with the name of the concrete simulation class.
+ */
+public abstract class BaseSimulation extends Simulation {
+
+    protected final AtomicInteger count = new AtomicInteger(1);
+    protected final Iterator<Map<String, Object>> feeder = Stream.generate(() -> Collections.singletonMap("count", (Object) count.getAndIncrement())).iterator();
+
+    protected HttpProtocolBuilder httpProtocol = http
+            .baseUrl("http://localhost:8080/v1")
+            .acceptHeader("application/json")
+            .contentTypeHeader("application/json")
+            .userAgentHeader("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+
+    protected Map<String, String> headers = Map.of("Content-Type", "application/json");
+
+    public abstract void loadTestingSetup();
+    public abstract void stressTestingSetup();
+    public abstract void soakTestingSetup();
+
+    public void setupSimulation(String testType) {
+        if (testType == null) {
+            testType = "LOAD";
+        }
+        switch (testType.toUpperCase()) {
+            case "LOAD":
+                loadTestingSetup();
+                break;
+            case "STRESS":
+                stressTestingSetup();
+                break;
+            case "SOAK":
+                soakTestingSetup();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown type: " + testType);
+        }
+    }
+}

--- a/api/src/gatling/java/simulations/GetAllSurveySimulation.java
+++ b/api/src/gatling/java/simulations/GetAllSurveySimulation.java
@@ -1,81 +1,71 @@
 package simulations;
 
 import io.gatling.javaapi.core.ScenarioBuilder;
-import io.gatling.javaapi.core.Simulation;
-import io.gatling.javaapi.http.HttpProtocolBuilder;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 import static io.gatling.javaapi.core.CoreDsl.*;
 import static io.gatling.javaapi.http.HttpDsl.*;
 
-public class GetAllSurveySimulation extends Simulation {
+public class GetAllSurveySimulation extends BaseSimulation {
 
-    HttpProtocolBuilder httpProtocol = http
-            .baseUrl("http://localhost:8080/v1")
-            .acceptHeader("application/json")
-            .contentTypeHeader("application/json")
-            .userAgentHeader("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+    private final ScenarioBuilder createSurveyScn;
+    private final ScenarioBuilder getAllSurveyScn;
 
-    Map<String, String> headers = Map.of("Content-Type", "application/json");
+    public GetAllSurveySimulation() {
+        createSurveyScn = scenario("Create Surveys")
+                .feed(feeder)
+                .exec(http("User Registration")
+                        .post("/auth/register")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            int count = session.getInt("count");
+                            String name = "testUser" + count;
+                            String email = "testUser" + count + "@gmail.com";
+                            String password = "Password40@";
+                            String phoneNumber = "01012345678";
+                            return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\",\"phoneNumber\":\"%s\"}", name, email, password, phoneNumber);
+                        })).asJson()
+                        .check(status().is(200)))
+                .pause(1)
+                .exec(http("User Login")
+                        .post("/auth/login")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            String email = "testUser" + session.getInt("count") + "@gmail.com";
+                            String password = "Password40@";
+                            return String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
+                        })).asJson()
+                        .check(status().is(200))
+                        .check(headerRegex("Set-Cookie", "JSESSIONID=(.*?);").saveAs("jsessionid")))
+                .pause(1)
+                .repeat(15, "n").on(
+                        exec(http("Create Survey #{n}")
+                                .post("/surveys")
+                                .headers(Map.of("Content-Type", "application/json"))
+                                .body(RawFileBody("data/survey_request.json")).asJson()
+                                .check(status().is(200))
+                        )
+                );
 
-    private static final AtomicInteger count = new AtomicInteger(1);
-    private static final Iterator<Map<String, Object>> feeder = Stream.generate(() -> Collections.singletonMap("count", (Object) count.getAndIncrement())).iterator();
+        getAllSurveyScn = scenario("Get All Surveys")
+                .exec(http("Get Surveys Page 1")
+                        .get("/surveys")
+                        .queryParam("page", "1")
+                        .check(jsonPath("$.surveys").exists())
+                        .headers(headers)
+                        .check(status().is(200))
+                );
+        String testType = System.getProperty("type");
+        setupSimulation(testType);
+    }
 
-    ScenarioBuilder createSurveysScn = scenario("Create Surveys")
-            .feed(feeder)
-            .exec(http("User Registration")
-                    .post("/auth/register")
-                    .headers(headers)
-                    .body(StringBody(session -> {
-                        int count = session.getInt("count");
-                        String name = "testUser" + count;
-                        String email = "testUser" + count + "@gmail.com";
-                        String password = "Password40@";
-                        String phoneNumber = "01012345678";
-                        return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\",\"phoneNumber\":\"%s\"}", name, email, password, phoneNumber);
-                    })).asJson()
-                    .check(status().is(200)))
-            .pause(1)
-            .exec(http("User Login")
-                    .post("/auth/login")
-                    .headers(headers)
-                    .body(StringBody(session -> {
-                        String email = "testUser" + session.getInt("count") + "@gmail.com";
-                        String password = "Password40@";
-                        return String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
-                    })).asJson()
-                    .check(status().is(200))
-                    .check(headerRegex("Set-Cookie", "JSESSIONID=(.*?);").saveAs("jsessionid")))
-            .pause(1)
-            .repeat(15, "n").on(
-                    exec(http("Create Survey #{n}")
-                            .post("/surveys")
-                            .headers(headers)
-                            .body(RawFileBody("data/survey_request.json")).asJson()
-                            .check(status().is(200))
-                    )
-            );
-
-    ScenarioBuilder getAllSurveysScn = scenario("Get All Surveys")
-            .exec(http("Get Surveys Page 1")
-                    .get("/surveys")
-                    .queryParam("page", "1")
-                    .check(jsonPath("$.surveys").exists())
-                    .headers(headers)
-                    .check(status().is(200))
-            );
-
-    // Load Testing Setup
+    @Override
     public void loadTestingSetup() {
         setUp(
-                createSurveysScn.injectOpen(atOnceUsers(1)),
-                getAllSurveysScn.injectOpen(
+                createSurveyScn.injectOpen(atOnceUsers(1)),
+                getAllSurveyScn.injectOpen(
                         nothingFor(5),
                         atOnceUsers(1000),
                         rampUsers(5000).during(Duration.ofSeconds(300))
@@ -83,47 +73,26 @@ public class GetAllSurveySimulation extends Simulation {
         ).protocols(httpProtocol);
     }
 
-    // Stress Testing Setup
+    @Override
     public void stressTestingSetup() {
         setUp(
-                createSurveysScn.injectOpen(atOnceUsers(1)),
-                getAllSurveysScn.injectOpen(
+                createSurveyScn.injectOpen(atOnceUsers(1)),
+                getAllSurveyScn.injectOpen(
                         nothingFor(5),
                         rampUsers(10000).during(Duration.ofSeconds(600))
                 )
         ).protocols(httpProtocol);
     }
 
-    // Soak Testing Setup
+    @Override
     public void soakTestingSetup() {
         setUp(
-                createSurveysScn.injectOpen(atOnceUsers(1)),
-                getAllSurveysScn.injectOpen(
+                createSurveyScn.injectOpen(atOnceUsers(1)),
+                getAllSurveyScn.injectOpen(
                         nothingFor(5),
                         constantUsersPerSec(50).during(Duration.ofMinutes(30))
                 )
         ).protocols(httpProtocol);
     }
 
-    // Main Simulation Setup
-    {
-        String testType = System.getProperty("type");
-        if (testType == null) {
-            testType = "LOAD"; // Default to LOAD if no system property is set
-        }
-
-        switch (testType.toUpperCase()) {
-            case "LOAD":
-                loadTestingSetup();
-                break;
-            case "STRESS":
-                stressTestingSetup();
-                break;
-            case "SOAK":
-                soakTestingSetup();
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown type: " + testType);
-        }
-    }
 }

--- a/api/src/gatling/java/simulations/GetAllSurveySimulation.java
+++ b/api/src/gatling/java/simulations/GetAllSurveySimulation.java
@@ -82,8 +82,7 @@ public class GetAllSurveySimulation extends Simulation {
                 getAllSurveysScn.injectOpen(
                         nothingFor(5), // wait for 5 seconds to ensure surveys are created
                         atOnceUsers(1000), // simulate 1000 users concurrently fetching surveys
-                        rampUsers(5000).during(Duration.ofSeconds(300)) // ramp up to 5000 users over 5 minutes
-                ).protocols(httpProtocol)
+                        rampUsers(5000).during(Duration.ofSeconds(300))) // ramp up to 5000 users over 5 minutes
         ).protocols(httpProtocol);
     }
 }

--- a/api/src/gatling/java/simulations/LoginSimulation.java
+++ b/api/src/gatling/java/simulations/LoginSimulation.java
@@ -1,38 +1,78 @@
 package simulations;
 
 import io.gatling.javaapi.core.ScenarioBuilder;
-import io.gatling.javaapi.core.Simulation;
-import io.gatling.javaapi.http.HttpProtocolBuilder;
 
-import java.util.Map;
+import java.time.Duration;
 
 import static io.gatling.javaapi.core.CoreDsl.*;
-import static io.gatling.javaapi.http.HttpDsl.http;
-import static io.gatling.javaapi.http.HttpDsl.status;
+import static io.gatling.javaapi.core.CoreDsl.constantUsersPerSec;
+import static io.gatling.javaapi.http.HttpDsl.*;
 
-public class LoginSimulation extends Simulation {
-    HttpProtocolBuilder httpProtocol = http
-            .baseUrl("http://localhost:8080/v1") // Base URL of your Spring Boot application
-            .acceptHeader("application/json")
-            .contentTypeHeader("application/json")
-            .userAgentHeader("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+public class LoginSimulation extends BaseSimulation {
 
-    Map<String, String> headers = Map.of("Content-Type", "application/json");
+    ScenarioBuilder loginScn;
 
-    ScenarioBuilder scn = scenario("User Registration and Login")
-            .exec(http("User Registration")
-                    .post("/auth/register")
-                    .headers(headers)
-                    .body(RawFileBody("data/register_request.json")).asJson()
-                    .check(status().is(200)))
-            .pause(1)
-            .exec(http("User Login")
-                    .post("/auth/login")
-                    .headers(headers)
-                    .body(RawFileBody("data/login_request.json")).asJson()
-                    .check(status().is(200)));
+    public LoginSimulation() {
+        loginScn = scenario("User Registration and Login")
+                .feed(feeder)
+                .exec(http("User Registration")
+                        .post("/auth/register")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            int count = session.getInt("count");
+                            String name = "testUser" + count;
+                            String email = "testUser" + count + "@gmail.com";
+                            String password = "Password40@";
+                            String phoneNumber = "01012345678";
+                            return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\",\"phoneNumber\":\"%s\"}", name, email, password, phoneNumber);
+                        })).asJson()
+                        .check(status().is(200)))
+                .pause(1)
+                .exec(http("User Login")
+                        .post("/auth/login")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            String email = "testUser" + session.getInt("count") + "@gmail.com";
+                            String password = "Password40@";
+                            return String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
+                        })).asJson()
+                        .check(status().is(200))
+                        .check(headerRegex("Set-Cookie", "JSESSIONID=(.*?);").saveAs("jsessionid")));
+        String testType = System.getProperty("type");
+        setupSimulation(testType);
+    }
 
-    {
-        setUp(scn.injectOpen(atOnceUsers(1))).protocols(httpProtocol);
+    @Override
+    public void loadTestingSetup() {
+        setUp(
+                loginScn.injectOpen(
+                        atOnceUsers(1),
+                        nothingFor(5),
+                        atOnceUsers(1000),
+                        rampUsers(5000).during(Duration.ofSeconds(300))
+                )
+        ).protocols(httpProtocol);
+    }
+
+    @Override
+    public void stressTestingSetup() {
+        setUp(
+                loginScn.injectOpen(
+                        atOnceUsers(1),
+                        nothingFor(5),
+                        rampUsers(10000).during(Duration.ofSeconds(600))
+                )
+        ).protocols(httpProtocol);
+    }
+
+    @Override
+    public void soakTestingSetup() {
+        setUp(
+                loginScn.injectOpen(
+                        atOnceUsers(1),
+                        nothingFor(5),
+                        constantUsersPerSec(50).during(Duration.ofMinutes(30))
+                )
+        ).protocols(httpProtocol);
     }
 }

--- a/api/src/gatling/java/simulations/SurveyCreateSimulation.java
+++ b/api/src/gatling/java/simulations/SurveyCreateSimulation.java
@@ -1,44 +1,84 @@
 package simulations;
 
 import io.gatling.javaapi.core.ScenarioBuilder;
-import io.gatling.javaapi.core.Simulation;
-import io.gatling.javaapi.http.HttpProtocolBuilder;
 
 import java.time.Duration;
-import java.util.Map;
 
 import static io.gatling.javaapi.core.CoreDsl.*;
 import static io.gatling.javaapi.http.HttpDsl.*;
 
-public class SurveyCreateSimulation extends Simulation {
+public class SurveyCreateSimulation extends BaseSimulation {
 
-    HttpProtocolBuilder httpProtocol = http
-            .baseUrl("http://localhost:8080/v1") // Base URL of your Spring Boot application
-            .contentTypeHeader("application/json")
-            .userAgentHeader("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+    private final ScenarioBuilder createSurveyScn;
 
-    Map<String, String> headers = Map.of("Content-Type", "application/json");
+    public SurveyCreateSimulation() {
+        createSurveyScn = scenario("Create Survey Scenario")
+                .feed(feeder)
+                .exec(http("User Registration")
+                        .post("/auth/register")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            int count = session.getInt("count");
+                            String name = "testUser" + count;
+                            String email = "testUser" + count + "@gmail.com";
+                            String password = "Password40@";
+                            String phoneNumber = "01012345678";
+                            return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\",\"phoneNumber\":\"%s\"}", name, email, password, phoneNumber);
+                        })).asJson()
+                        .check(status().is(200)))
+                .pause(1)
+                .exec(http("User Login")
+                        .post("/auth/login")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            String email = "testUser" + session.getInt("count") + "@gmail.com";
+                            String password = "Password40@";
+                            return String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
+                        })).asJson()
+                        .check(status().is(200))
+                        .check(headerRegex("Set-Cookie", "JSESSIONID=(.*?);").saveAs("jsessionid")))
+                .pause(1)
+                .exec(http("Create Survey")
+                        .post("/surveys")
+                        .headers(headers)
+                        .body(RawFileBody("data/survey_request.json")).asJson()
+                        .check(status().is(200))
+                        .check(jsonPath("$.surveyId").saveAs("surveyId")));
+        String testType = System.getProperty("type");
+        setupSimulation(testType);
+    }
 
-    ScenarioBuilder scn = scenario("Survey Create Scenario")
-            .exec(http("User Registration")
-                    .post("/auth/register")
-                    .headers(headers)
-                    .body(RawFileBody("data/register_request.json")).asJson()
-                    .check(status().is(200)))
-            .pause(1)
-            .exec(http("User Login")
-                    .post("/auth/login")
-                    .headers(headers)
-                    .body(RawFileBody("data/login_request.json")).asJson()
-                    .check(status().is(200)))
-            .pause(1)
-            .exec(http("Create Survey")
-                    .post("/surveys")
-                    .headers(headers)
-                    .body(RawFileBody("data/survey_request.json")).asJson()
-                    .check(status().is(200))
-                    .check(jsonPath("$.surveyId").saveAs("surveyId")));
-    {
-        setUp(scn.injectOpen(rampUsers(1).during(Duration.ofSeconds(10)))).protocols(httpProtocol);
+    @Override
+    public void loadTestingSetup() {
+        setUp(
+                createSurveyScn.injectOpen(
+                        atOnceUsers(1),
+                        nothingFor(5),
+                        atOnceUsers(1000),
+                        rampUsers(5000).during(Duration.ofSeconds(300))
+                )
+        ).protocols(httpProtocol);
+    }
+
+    @Override
+    public void stressTestingSetup() {
+        setUp(
+                createSurveyScn.injectOpen(
+                        atOnceUsers(1),
+                        nothingFor(5),
+                        rampUsers(10000).during(Duration.ofSeconds(600))
+                )
+        ).protocols(httpProtocol);
+    }
+
+    @Override
+    public void soakTestingSetup() {
+        setUp(
+                createSurveyScn.injectOpen(
+                        atOnceUsers(1),
+                        nothingFor(5),
+                        constantUsersPerSec(50).during(Duration.ofMinutes(30))
+                )
+        ).protocols(httpProtocol);
     }
 }

--- a/api/src/gatling/java/simulations/SurveyCreateSimulation.java
+++ b/api/src/gatling/java/simulations/SurveyCreateSimulation.java
@@ -19,7 +19,7 @@ public class SurveyCreateSimulation extends Simulation {
 
     Map<String, String> headers = Map.of("Content-Type", "application/json");
 
-    ScenarioBuilder scn = scenario("Survey Operations")
+    ScenarioBuilder scn = scenario("Survey Create Scenario")
             .exec(http("User Registration")
                     .post("/auth/register")
                     .headers(headers)

--- a/api/src/gatling/java/simulations/SurveySubmitAnswerSimulation.java
+++ b/api/src/gatling/java/simulations/SurveySubmitAnswerSimulation.java
@@ -1,0 +1,128 @@
+package simulations;
+
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.*;
+
+public class SurveySubmitAnswerSimulation extends Simulation {
+
+        HttpProtocolBuilder httpProtocol = http
+                .baseUrl("http://localhost:8080/v1") // Base URL of your Spring Boot application
+                .acceptHeader("application/json")
+                .contentTypeHeader("application/json")
+                .userAgentHeader("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+
+        Map<String, String> headers = Map.of("Content-Type", "application/json");
+
+        // AtomicInteger to ensure unique counts
+        private static final AtomicInteger count = new AtomicInteger(1);
+
+        // Iterator to provide unique count values
+        private static final Iterator<Map<String, Object>> feeder = Stream.generate(() -> Collections.singletonMap("count", (Object) count.getAndIncrement())).iterator();
+
+        // Scenario to create a survey
+        ScenarioBuilder createSurveysScn = scenario("Survey Create Scenario")
+                .exec(http("User Registration")
+                        .post("/auth/register")
+                        .headers(headers)
+                        .body(RawFileBody("data/register_request.json")).asJson()
+                        .check(status().is(200)))
+                .pause(1)
+                .exec(http("User Login")
+                        .post("/auth/login")
+                        .headers(headers)
+                        .body(RawFileBody("data/login_request.json")).asJson()
+                        .check(status().is(200)))
+                .pause(1)
+                .exec(http("Create Survey")
+                        .post("/surveys")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            String now = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+                            return "{"
+                                    + "\"title\": \"카카오 사용자분들께 설문 부탁드립니다!\","
+                                    + "\"description\": \"카카오 앱 서비스에 대한 전반적인 만족도 조사입니다.\","
+                                    + "\"startedDate\": \"" + now + "\","
+                                    + "\"endedDate\": \"2099-07-09T06:17:27.905Z\","
+                                    + "\"certificationTypes\": [],"
+                                    + "\"questions\": ["
+                                    + "  {"
+                                    + "    \"title\": \"카카오톡 서비스 사용자이신가요?\","
+                                    + "    \"description\": \"카카오톡 사용자여부 확인\","
+                                    + "    \"questionType\": \"SINGLE_CHOICE\","
+                                    + "    \"questionNo\": 1,"
+                                    + "    \"isRequired\": true,"
+                                    + "    \"questionOptions\": ["
+                                    + "      {"
+                                    + "        \"option\": \"예\","
+                                    + "        \"description\": \"사용자\""
+                                    + "      }"
+                                    + "    ]"
+                                    + "  }"
+                                    + "]"
+                                    + "}";
+                        })).asJson()
+                        .check(status().is(200))
+                        .check(jsonPath("$.surveyId").saveAs("surveyId")));
+
+    // Scenario to create a survey
+    ScenarioBuilder submitSurveysScn = scenario("Submit Survey Scenario")
+            .feed(feeder)
+            .exec(http("User Registration")
+                    .post("/auth/register")
+                    .headers(headers)
+                    .body(StringBody(session -> {
+                        int count = session.getInt("count");
+                        String name = "testUser" + count;
+                        String email = "testUser" + count + "@gmail.com";
+                        String password = "Password40@";
+                        String phoneNumber = "01012345678";
+                        return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\",\"phoneNumber\":\"%s\"}", name, email, password, phoneNumber);
+                    })).asJson()
+                    .check(status().is(200)))
+            .pause(1)
+            .exec(http("User Login")
+                    .post("/auth/login")
+                    .headers(headers)
+                    .body(StringBody(session -> {
+                        String email = "testUser" + session.getInt("count") + "@gmail.com";
+                        String password = "Password40@";
+                        return String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
+                    })).asJson()
+                    .check(status().is(200))
+                    .check(headerRegex("Set-Cookie", "JSESSIONID=(.*?);").saveAs("jsessionid")))
+            .pause(1)
+            .exec(http("Submit Survey")
+                    .post("/surveys/submit")
+                    .headers(Map.of("Content-Type", "application/json", "Cookie", "JSESSIONID=${jsessionid}"))
+                    .body(RawFileBody("data/submit_request.json")).asJson()
+                    .check(status().is(200))
+            );
+
+    {
+        setUp(
+                createSurveysScn.injectOpen(atOnceUsers(1)),
+                submitSurveysScn.injectOpen(
+                        nothingFor(3), // wait for 3 seconds to ensure surveys are created
+                        atOnceUsers(1000), // simulate 1000 users concurrently fetching surveys
+                        rampUsers(1000).during(Duration.ofSeconds(300)) // ramp up to 1000 users over 5 minutes
+                )
+        ).protocols(httpProtocol);
+    }
+
+
+
+
+}

--- a/api/src/gatling/java/simulations/SurveySubmitAnswerSimulation.java
+++ b/api/src/gatling/java/simulations/SurveySubmitAnswerSimulation.java
@@ -1,39 +1,22 @@
 package simulations;
 
 import io.gatling.javaapi.core.ScenarioBuilder;
-import io.gatling.javaapi.core.Simulation;
-import io.gatling.javaapi.http.HttpProtocolBuilder;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 import static io.gatling.javaapi.core.CoreDsl.*;
 import static io.gatling.javaapi.http.HttpDsl.*;
 
-public class SurveySubmitAnswerSimulation extends Simulation {
+public class SurveySubmitAnswerSimulation extends BaseSimulation {
 
-        HttpProtocolBuilder httpProtocol = http
-                .baseUrl("http://localhost:8080/v1") // Base URL of your Spring Boot application
-                .acceptHeader("application/json")
-                .contentTypeHeader("application/json")
-                .userAgentHeader("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36");
+    private final ScenarioBuilder createSurveyScn;
+    private final ScenarioBuilder submitSurveyScn;
 
-        Map<String, String> headers = Map.of("Content-Type", "application/json");
-
-        // AtomicInteger to ensure unique counts
-        private static final AtomicInteger count = new AtomicInteger(1);
-
-        // Iterator to provide unique count values
-        private static final Iterator<Map<String, Object>> feeder = Stream.generate(() -> Collections.singletonMap("count", (Object) count.getAndIncrement())).iterator();
-
-        // Scenario to create a survey
-        ScenarioBuilder createSurveysScn = scenario("Survey Create Scenario")
+    public SurveySubmitAnswerSimulation() {
+        createSurveyScn = scenario("Survey Create Scenario")
                 .exec(http("User Registration")
                         .post("/auth/register")
                         .headers(headers)
@@ -77,44 +60,47 @@ public class SurveySubmitAnswerSimulation extends Simulation {
                         .check(status().is(200))
                         .check(jsonPath("$.surveyId").saveAs("surveyId")));
 
-    // Scenario to create a survey
-    ScenarioBuilder submitSurveysScn = scenario("Submit Survey Scenario")
-            .feed(feeder)
-            .exec(http("User Registration")
-                    .post("/auth/register")
-                    .headers(headers)
-                    .body(StringBody(session -> {
-                        int count = session.getInt("count");
-                        String name = "testUser" + count;
-                        String email = "testUser" + count + "@gmail.com";
-                        String password = "Password40@";
-                        String phoneNumber = "01012345678";
-                        return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\",\"phoneNumber\":\"%s\"}", name, email, password, phoneNumber);
-                    })).asJson()
-                    .check(status().is(200)))
-            .pause(1)
-            .exec(http("User Login")
-                    .post("/auth/login")
-                    .headers(headers)
-                    .body(StringBody(session -> {
-                        String email = "testUser" + session.getInt("count") + "@gmail.com";
-                        String password = "Password40@";
-                        return String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
-                    })).asJson()
-                    .check(status().is(200))
-                    .check(headerRegex("Set-Cookie", "JSESSIONID=(.*?);").saveAs("jsessionid")))
-            .pause(1)
-            .exec(http("Submit Survey")
-                    .post("/surveys/submit")
-                    .headers(Map.of("Content-Type", "application/json", "Cookie", "JSESSIONID=${jsessionid}"))
-                    .body(RawFileBody("data/submit_request.json")).asJson()
-                    .check(status().is(200))
-            );
+        submitSurveyScn = scenario("Submit Survey Scenario")
+                .feed(feeder)
+                .exec(http("User Registration")
+                        .post("/auth/register")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            int count = session.getInt("count");
+                            String name = "testUser" + count;
+                            String email = "testUser" + count + "@gmail.com";
+                            String password = "Password40@";
+                            String phoneNumber = "01012345678";
+                            return String.format("{\"name\":\"%s\",\"email\":\"%s\",\"password\":\"%s\",\"phoneNumber\":\"%s\"}", name, email, password, phoneNumber);
+                        })).asJson()
+                        .check(status().is(200)))
+                .pause(1)
+                .exec(http("User Login")
+                        .post("/auth/login")
+                        .headers(headers)
+                        .body(StringBody(session -> {
+                            String email = "testUser" + session.getInt("count") + "@gmail.com";
+                            String password = "Password40@";
+                            return String.format("{\"email\":\"%s\",\"password\":\"%s\"}", email, password);
+                        })).asJson()
+                        .check(status().is(200))
+                        .check(headerRegex("Set-Cookie", "JSESSIONID=(.*?);").saveAs("jsessionid")))
+                .pause(1)
+                .exec(http("Submit Survey")
+                        .post("/surveys/submit")
+                        .headers(Map.of("Content-Type", "application/json", "Cookie", "JSESSIONID=${jsessionid}"))
+                        .body(RawFileBody("data/submit_request.json")).asJson()
+                        .check(status().is(200))
+                );
+        String testType = System.getProperty("type");
+        setupSimulation(testType);
+    }
 
+    @Override
     public void loadTestingSetup() {
         setUp(
-                createSurveysScn.injectOpen(atOnceUsers(1)),
-                submitSurveysScn.injectOpen(
+                createSurveyScn.injectOpen(atOnceUsers(1)),
+                submitSurveyScn.injectOpen(
                         nothingFor(5),
                         atOnceUsers(1000),
                         rampUsers(5000).during(Duration.ofSeconds(300))
@@ -122,45 +108,26 @@ public class SurveySubmitAnswerSimulation extends Simulation {
         ).protocols(httpProtocol);
     }
 
+    @Override
     public void stressTestingSetup() {
         setUp(
-                createSurveysScn.injectOpen(atOnceUsers(1)),
-                submitSurveysScn.injectOpen(
+                createSurveyScn.injectOpen(atOnceUsers(1)),
+                submitSurveyScn.injectOpen(
                         nothingFor(5),
                         rampUsers(10000).during(Duration.ofSeconds(600))
                 )
         ).protocols(httpProtocol);
     }
 
+    @Override
     public void soakTestingSetup() {
         setUp(
-                createSurveysScn.injectOpen(atOnceUsers(1)),
-                submitSurveysScn.injectOpen(
+                createSurveyScn.injectOpen(atOnceUsers(1)),
+                submitSurveyScn.injectOpen(
                         nothingFor(5),
                         constantUsersPerSec(50).during(Duration.ofMinutes(30))
                 )
         ).protocols(httpProtocol);
-    }
-
-    {
-        String testType = System.getProperty("type");
-        if (testType == null) {
-            testType = "LOAD";
-        }
-
-        switch (testType.toUpperCase()) {
-            case "LOAD":
-                loadTestingSetup();
-                break;
-            case "STRESS":
-                stressTestingSetup();
-                break;
-            case "SOAK":
-                soakTestingSetup();
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown type: " + testType);
-        }
     }
 
 }

--- a/api/src/gatling/resources/data/login_request.json
+++ b/api/src/gatling/resources/data/login_request.json
@@ -1,4 +1,4 @@
 {
-  "email": "test1@gmail.com",
+  "email": "test@gmail.com",
   "password": "Password40@"
 }

--- a/api/src/gatling/resources/data/register_request.json
+++ b/api/src/gatling/resources/data/register_request.json
@@ -1,6 +1,6 @@
 {
-  "name": "test1",
-  "email": "test1@gmail.com",
+  "name": "test",
+  "email": "test@gmail.com",
   "password": "Password40@",
   "phoneNumber": "01012345678"
 }

--- a/api/src/gatling/resources/data/submit_request.json
+++ b/api/src/gatling/resources/data/submit_request.json
@@ -1,0 +1,11 @@
+{
+  "answers": [
+    {
+      "questionBankId": 1,
+      "isRequired": true,
+      "questionType": "SINGLE_CHOICE",
+      "singleChoice": 1
+    }
+  ],
+  "surveyId": 1
+}

--- a/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
+++ b/api/src/main/java/com/thesurvey/api/controller/SurveyController.java
@@ -51,7 +51,7 @@ public class SurveyController {
         return ResponseEntity.ok(surveyService.getAllSurvey(page));
     }
 
-    @Operation(summary = "개별 설문조사 조회", description = "파라미터로 전달 받은 UUID에 해당하는 설문조사를 조회합니다.")
+    @Operation(summary = "개별 설문조사 조회", description = "파라미터로 전달 받은 ID에 해당하는 설문조사를 조회합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "요청 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),
@@ -94,7 +94,7 @@ public class SurveyController {
             surveyService.updateSurvey(surveyUpdateRequestDto));
     }
 
-    @Operation(summary = "설문조사 삭제", description = "파라미터로 전달 받은 UUID에 해당하는 설문조사를 삭제합니다.")
+    @Operation(summary = "설문조사 삭제", description = "파라미터로 전달 받은 ID에 해당하는 설문조사를 삭제합니다.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "204", description = "요청 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(schema = @Schema(hidden = true))),

--- a/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
@@ -14,11 +14,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PointHistory {
 
-    @Id
-    @Column(name = "transaction_date")
-    private LocalDateTime transactionDate;
+    @EmbeddedId
+    private PointHistoryId id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("userId")  // This is the name of the attribute in PointHistoryId
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -27,7 +27,7 @@ public class PointHistory {
 
     @Builder
     public PointHistory(User user, LocalDateTime transactionDate, Integer operandPoint) {
-        this.transactionDate = transactionDate;
+        this.id = new PointHistoryId(transactionDate, user.getUserId());
         this.user = user;
         this.operandPoint = operandPoint;
     }

--- a/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
@@ -18,7 +18,7 @@ public class PointHistory {
     private PointHistoryId id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("userId")  // This is the name of the attribute in PointHistoryId
+    @MapsId("userId")
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/api/src/main/java/com/thesurvey/api/domain/PointHistoryId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistoryId.java
@@ -1,0 +1,37 @@
+package com.thesurvey.api.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Embeddable
+public class PointHistoryId implements Serializable {
+
+    @Column(name = "transaction_date")
+    private LocalDateTime transactionDate;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    public PointHistoryId() {}
+
+    public PointHistoryId(LocalDateTime transactionDate, Long userId) {
+        this.transactionDate = transactionDate;
+        this.userId = userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PointHistoryId that = (PointHistoryId) o;
+        return transactionDate.equals(that.transactionDate) && userId.equals(that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transactionDate, userId);
+    }
+}

--- a/api/src/main/java/com/thesurvey/api/domain/Survey.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Survey.java
@@ -14,7 +14,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
-@Table(name = "survey")
+@Table(name = "survey", indexes = {
+        @Index(name = "idx_survey_survey_id", columnList = "survey_id")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Survey extends BaseTimeEntity {

--- a/api/src/main/java/com/thesurvey/api/domain/Survey.java
+++ b/api/src/main/java/com/thesurvey/api/domain/Survey.java
@@ -14,9 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
-@Table(name = "survey", indexes = {
-        @Index(name = "idx_survey_survey_id", columnList = "survey_id")
-})
+@Table(name = "survey")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Survey extends BaseTimeEntity {

--- a/api/src/main/resources/application-revision.yml
+++ b/api/src/main/resources/application-revision.yml
@@ -19,6 +19,13 @@ spring:
     url: jdbc:postgresql://localhost:5432/the_survey_revision
     username: the_survey_revision
     password: the_survey_revision
+    hikari:
+      maximum-pool-size: 50
+      minimum-idle: 20
+      idle-timeout: 30000
+      max-lifetime: 1800000
+      connection-timeout: 10000
+
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:


### PR DESCRIPTION
이 PR은 다음을 수행하였습니다:

1. Gatling의 BaseSimulation, Submit Survey Scenario 추가

- 설문조사에 응답하는 요청 시나리오를 구현하였습니다. 설문조사에 참여하기 위해서 survey의 startedDate를 미래 시점으로 하면 유효성 검사를 통과할 수 없으므로,, 현재 시간을 사용하도록 하였습니다.
- BaseSimulation은 Simulation에 필요한 HTTP 관련 설정 정보를 포함합니다.

또한 Simulation에따라 부하 정도를 다르게 하기 위해서 다음과 같은 추상메서드를 구현해야 합니다.

LOAD 테스트: 예상 부하 조건에서 시스템이 어떻게 성능을 발휘하는지 확인합니다.
```java
    @Override
    public void loadTestingSetup() {
        setUp(
                createSurveyScn.injectOpen(atOnceUsers(1)),
                submitSurveyScn.injectOpen(
                        nothingFor(5),
                        atOnceUsers(1000),
                        rampUsers(5000).during(Duration.ofSeconds(300))
                )
        ).protocols(httpProtocol);
    }
```

STRESS 테스트: 부하를 점진적으로 증가시켜 시스템이 실패할 때까지 시스템의 한계점을 식별합니다.

```java
    @Override
    public void stressTestingSetup() {
        setUp(
                createSurveyScn.injectOpen(atOnceUsers(1)),
                submitSurveyScn.injectOpen(
                        nothingFor(5),
                        rampUsers(10000).during(Duration.ofSeconds(600))
                )
        ).protocols(httpProtocol);
    }
```

SOAK 테스트: 장시간 동안 일정한 사용자 수를 사용하여 시스템의 안정성을 테스트합니다.
```java
    @Override
    public void soakTestingSetup() {
        setUp(
                createSurveyScn.injectOpen(atOnceUsers(1)),
                submitSurveyScn.injectOpen(
                        nothingFor(5),
                        constantUsersPerSec(50).during(Duration.ofMinutes(30))
                )
        ).protocols(httpProtocol);
    }
```
---

### hicariCP 파라미터 조정
```yml
hikari:
      maximum-pool-size: 50
      minimum-idle: 20
      idle-timeout: 30000
      max-lifetime: 1800000
      connection-timeout: 10000
```
위와 같이 설정한 이유는 다음과 같습니다. 

### maximum-pool-size
이전값: 10
변경값: 50
50개의 connection을 유지함으로써 더 많은 동시 요청을 처리할 수 있도록 하였습니다.

### minimum-idle
이전값: 기본적으로 maximum-pool-size와 동일하게 설정됨
변경값: 20
20개의 최소 idle connection을 유지하여 요청이 들어오면 바로 사용할 수 있는 connection을 보장합니다. 이는 요청이 들어올 때마다 새로운 connection을 생성할 필요 없이 빠르게 응답할 수 있도록 합니다.

### idle-timeout
이전값: 600000 (10분)
변경값: 30000 (30초)
사용되고 반환된 idle connection을 30초 동안만 유지합니다.이는 빠르게 불필요한 리소스를 해제하기 위함입니다.

### max-lifetime
이전값: 1800000 (30분)

이는 기본값을 사용했습니다. connection을 30분 동안 유지합니다. 이는 주기적으로 connection을 새로고침하여 오래된 connection을 방지합니다.

### connection-timeout
Spring 기본값: 30000 (30초)
변경값: 10000 (10초)

Connection을 10초 동안만 기다리므로, 더 빠르게 실패를 감지하고 대응할 수 있습니다. 이는 대기 시간을 줄이는 더 나은 사용자 경험을 제공합니다.

---

추가적으로 이전에 삭제했던 PointHistoryId를 다시 추가하였습니다. 그 이유는, PK가 transactionDate일 경우 동시에 transactionDate가 저장되었을 때 Duplicate key 문제가 발생하기 때문입니다.
