### PR TITLE
refactor: User 데이터를 Authentication 에서 가져오도록 수정

### DIFF
--- a/api/src/main/java/com/thesurvey/api/config/LoginAuthenticationFilter.java
+++ b/api/src/main/java/com/thesurvey/api/config/LoginAuthenticationFilter.java
@@ -1,11 +1,12 @@
 package com.thesurvey.api.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thesurvey.api.domain.User;
 import com.thesurvey.api.dto.request.user.UserLoginRequestDto;
 import com.thesurvey.api.dto.response.user.UserResponseDto;
 import com.thesurvey.api.exception.ErrorMessage;
 import com.thesurvey.api.exception.mapper.BadRequestExceptionMapper;
-import com.thesurvey.api.service.UserService;
+import com.thesurvey.api.service.mapper.UserMapper;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -23,19 +24,19 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
 
     private final AuthenticationManager authenticationManager;
 
-    private final UserService userService;
-
     private final ObjectMapper objectMapper;
 
-    public LoginAuthenticationFilter(AuthenticationManager authenticationManager, UserService userService, ObjectMapper objectMapper) {
+    private final UserMapper userMapper;
+
+    public LoginAuthenticationFilter(AuthenticationManager authenticationManager, ObjectMapper objectMapper, UserMapper userMapper) {
         this.authenticationManager = authenticationManager;
-        this.userService = userService;
         this.objectMapper = objectMapper;
+        this.userMapper = userMapper;
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
-        UserLoginRequestDto userLoginRequestDto = null;
+        UserLoginRequestDto userLoginRequestDto;
         try {
             userLoginRequestDto = new ObjectMapper().readValue(request.getInputStream(), UserLoginRequestDto.class);
         } catch (IOException e) {
@@ -56,7 +57,7 @@ public class LoginAuthenticationFilter extends UsernamePasswordAuthenticationFil
         response.setContentType("application/json;");
         response.setCharacterEncoding("UTF-8");
 
-        UserResponseDto userResponseDto = userService.getUserByName(authentication.getName());
+        UserResponseDto userResponseDto = userMapper.toUserResponseDto((User) authentication.getPrincipal());
         String jsonResponse = objectMapper.writeValueAsString(userResponseDto);
         PrintWriter writer = response.getWriter();
         writer.write(jsonResponse);

--- a/api/src/main/java/com/thesurvey/api/config/SecurityConfig.java
+++ b/api/src/main/java/com/thesurvey/api/config/SecurityConfig.java
@@ -5,7 +5,7 @@ import com.thesurvey.api.exception.AuthenticationEntryPointHandler;
 import com.thesurvey.api.exception.ErrorMessage;
 import com.thesurvey.api.exception.mapper.NotFoundExceptionMapper;
 import com.thesurvey.api.repository.UserRepository;
-import com.thesurvey.api.service.UserService;
+import com.thesurvey.api.service.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +38,7 @@ public class SecurityConfig {
 
     private final UserRepository userRepository;
 
-    private final UserService userService;
+    private final UserMapper userMapper;
 
     private final ObjectMapper objectMapper;
 
@@ -46,7 +46,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         LoginAuthenticationFilter loginAuthenticationFilter = new LoginAuthenticationFilter(
-                authenticationManager(http.getSharedObject(AuthenticationConfiguration.class)), userService, objectMapper);
+                        authenticationManager(http.getSharedObject(AuthenticationConfiguration.class)), objectMapper, userMapper);
         loginAuthenticationFilter.setFilterProcessesUrl("/auth/login");
 
         // @formatter:off

--- a/api/src/main/java/com/thesurvey/api/util/UserUtil.java
+++ b/api/src/main/java/com/thesurvey/api/util/UserUtil.java
@@ -2,10 +2,8 @@ package com.thesurvey.api.util;
 
 import com.thesurvey.api.domain.User;
 import com.thesurvey.api.exception.ErrorMessage;
-import com.thesurvey.api.exception.mapper.NotFoundExceptionMapper;
 import com.thesurvey.api.exception.mapper.UnauthorizedRequestExceptionMapper;
 import com.thesurvey.api.repository.UserRepository;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -20,25 +18,13 @@ public class UserUtil {
 
     public static User getUserFromAuthentication(Authentication authentication) {
         validateUserAuthentication(authentication);
-        return userRepository.findByName(authentication.getName()).orElseThrow(
-            () -> new NotFoundExceptionMapper(ErrorMessage.USER_NAME_NOT_FOUND,
-                authentication.getName()));
+        return (User) authentication.getPrincipal();
     }
 
     public static Long getUserIdFromAuthentication(Authentication authentication) {
         validateUserAuthentication(authentication);
-        User user = userRepository.findByName(authentication.getName()).orElseThrow(
-            () -> new NotFoundExceptionMapper(ErrorMessage.USER_NAME_NOT_FOUND,
-                authentication.getName()));
+        User user = (User) authentication.getPrincipal();
         return user.getUserId();
-    }
-
-    public static String getUserNameFromAuthentication(Authentication authentication) {
-        validateUserAuthentication(authentication);
-        User user = userRepository.findByName(authentication.getName()).orElseThrow(
-            () -> new NotFoundExceptionMapper(ErrorMessage.USER_NAME_NOT_FOUND,
-                authentication.getName()));
-        return user.getName();
     }
 
     public static void validateUserAuthentication(Authentication authentication) {


### PR DESCRIPTION
이 PR에서는 기존 User 데이터를 Repository에서 불러오는 로직을 Authentication에서 가져오는 로직으로 수정합니다.

Authentication 객체가 생성될 때, UserDetails 객체를 포함함으로써 사용자에 대한 모든 필요한 정보를 저장할 수 있습니다. 
Spring Security는 ThreadLocal 변수 안에 SecurityContextHolder를 저장합니다.
그리고 인증된 사용자의 Authentication 객체는 SecurityContextHolder에 저장됩니다. 이를 통해 현재 인증된 사용자의 정보를 애플리케이션 어디서든 접근할 수 있습니다. 

```java
    @Bean
    public UserDetailsService userDetailsService() {
        return email -> userRepository.findByEmail(email)
                .orElseThrow(() -> new NotFoundExceptionMapper(ErrorMessage.USER_NAME_NOT_FOUND, email));
    }
```

로그인 인증 과정에서 이 코드에서 이미 User 데이터를 불러오기 때문에 다시 Repository에서 User를 불러올 필요가 없습니다.