### PR TITLE
fix: 복합키를 사용하는 엔티티 삭제가 안 되던 문제 수정

### DIFF
--- a/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistory.java
@@ -15,20 +15,15 @@ import java.time.LocalDateTime;
 public class PointHistory {
 
     @EmbeddedId
-    private PointHistoryId id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("userId")
-    @JoinColumn(name = "user_id")
-    private User user;
+    @AttributeOverride(name = "transactionDate", column = @Column(name = "transaction_date"))
+    private PointHistoryId pointHistoryId;
 
     @Column(name = "operand_point")
     private Integer operandPoint;
 
     @Builder
     public PointHistory(User user, LocalDateTime transactionDate, Integer operandPoint) {
-        this.id = new PointHistoryId(transactionDate, user.getUserId());
-        this.user = user;
+        this.pointHistoryId = new PointHistoryId(transactionDate, user);
         this.operandPoint = operandPoint;
     }
 

--- a/api/src/main/java/com/thesurvey/api/domain/PointHistoryId.java
+++ b/api/src/main/java/com/thesurvey/api/domain/PointHistoryId.java
@@ -1,7 +1,9 @@
 package com.thesurvey.api.domain;
 
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -9,17 +11,17 @@ import java.util.Objects;
 @Embeddable
 public class PointHistoryId implements Serializable {
 
-    @Column(name = "transaction_date")
     private LocalDateTime transactionDate;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    public User user;
 
     public PointHistoryId() {}
 
-    public PointHistoryId(LocalDateTime transactionDate, Long userId) {
+    public PointHistoryId(LocalDateTime transactionDate, User user) {
         this.transactionDate = transactionDate;
-        this.userId = userId;
+        this.user = user;
     }
 
     @Override
@@ -27,11 +29,11 @@ public class PointHistoryId implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PointHistoryId that = (PointHistoryId) o;
-        return transactionDate.equals(that.transactionDate) && userId.equals(that.userId);
+        return transactionDate.equals(that.transactionDate) && user.equals(that.user);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(transactionDate, userId);
+        return Objects.hash(transactionDate, user);
     }
 }

--- a/api/src/main/java/com/thesurvey/api/domain/User.java
+++ b/api/src/main/java/com/thesurvey/api/domain/User.java
@@ -35,7 +35,6 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @OneToMany(
         mappedBy = "participationId.user",
-        cascade = CascadeType.ALL,
         orphanRemoval = true
     )
     private List<Participation> participations;
@@ -49,14 +48,12 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @OneToMany(
         mappedBy = "userCertificationId.user",
-        cascade = CascadeType.ALL,
         orphanRemoval = true
     )
     private List<UserCertification> userCertifications;
 
     @OneToMany(
-        mappedBy = "user",
-        cascade = CascadeType.ALL,
+        mappedBy = "pointHistoryId.user",
         orphanRemoval = true
     )
     private List<PointHistory> pointHistories;

--- a/api/src/main/java/com/thesurvey/api/repository/ParticipationRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/ParticipationRepository.java
@@ -3,7 +3,9 @@ package com.thesurvey.api.repository;
 import com.thesurvey.api.domain.Participation;
 import com.thesurvey.api.domain.ParticipationId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,4 +18,8 @@ public interface ParticipationRepository extends JpaRepository<Participation, Pa
 
     @Query("SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END FROM Participation p WHERE p.participationId.user.userId = :userId AND p.participationId.survey.surveyId = :surveyId")
     boolean existsByUserIdAndSurveyId(Long userId, Long surveyId);
+
+    @Modifying
+    @Query("DELETE FROM Participation p WHERE p.participationId.survey.surveyId = :surveyId")
+    void deleteBySurveyId(@Param("surveyId") Long surveyId);
 }

--- a/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
+++ b/api/src/main/java/com/thesurvey/api/repository/QuestionRepository.java
@@ -3,6 +3,7 @@ package com.thesurvey.api.repository;
 import com.thesurvey.api.domain.Question;
 import com.thesurvey.api.domain.QuestionId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -23,4 +24,8 @@ public interface QuestionRepository extends JpaRepository<Question, QuestionId> 
 
     @Query("SELECT q.isRequired FROM Question q WHERE q.questionId.questionBank.questionBankId = :questionBankId")
     Optional<Boolean> findIsRequiredByQuestionBankId(Long questionBankId);
+
+    @Modifying
+    @Query("DELETE FROM Question q WHERE q.questionId.survey.surveyId = :surveyId")
+    void deleteBySurveyId(Long surveyId);
 }

--- a/api/src/main/java/com/thesurvey/api/service/ParticipationService.java
+++ b/api/src/main/java/com/thesurvey/api/service/ParticipationService.java
@@ -1,7 +1,6 @@
 package com.thesurvey.api.service;
 
 import com.thesurvey.api.domain.EnumTypeEntity.CertificationType;
-import com.thesurvey.api.domain.Participation;
 import com.thesurvey.api.domain.Survey;
 import com.thesurvey.api.domain.User;
 import com.thesurvey.api.repository.ParticipationRepository;
@@ -31,7 +30,6 @@ public class ParticipationService {
 
     @Transactional
     public void deleteParticipation(Long surveyId) {
-        List<Participation> participationList = participationRepository.findAllBySurveyId(surveyId);
-        participationRepository.deleteAll(participationList);
+        participationRepository.deleteBySurveyId(surveyId);
     }
 }

--- a/api/src/main/java/com/thesurvey/api/service/QuestionService.java
+++ b/api/src/main/java/com/thesurvey/api/service/QuestionService.java
@@ -137,8 +137,7 @@ public class QuestionService {
     @Transactional
     public void deleteQuestion(Long surveyId) {
         log.info("Deleting questions for survey ID: {}", surveyId);
-        List<Question> questionList = questionRepository.findAllBySurveyId(surveyId);
-        questionRepository.deleteAll(questionList);
+        questionRepository.deleteBySurveyId(surveyId);
         log.info("Questions deleted for survey ID: {}", surveyId);
     }
 }


### PR DESCRIPTION
이 PR에서는 복합키를 사용하는 엔티티가 삭제되지 않던 문제를 수정했습니다.

Cascade.ALL이 설정되어 있었으나, 복합키를 사용하는 엔티티가 삭제되어도 자식 엔티티가 삭제되고 있지 않았습니다.
정확한 원인은 파악하지 못했으나, 일단은 직접 쿼리를 작성하여 지우도록 변경하였습니다.
